### PR TITLE
feat: use online representation of 50% of total weight as a consensus threshold

### DIFF
--- a/common/types/balance.go
+++ b/common/types/balance.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/qlcchain/go-qlc/common/util"
 	"github.com/tinylib/msgp/msgp"
-	"math/big"
 )
 
 func init() {
@@ -76,6 +77,13 @@ func (b Balance) Add(n Balance) Balance {
 func (b Balance) Sub(n Balance) Balance {
 	sub := new(big.Int).Sub(b.Int, n.Int)
 	return Balance{sub}
+}
+
+// Div balances div
+func (b Balance) Div(n int64) Balance {
+	div := b.Int64() / n
+	b1 := new(big.Int).SetInt64(div)
+	return Balance{b1}
 }
 
 //Compare two balances

--- a/common/types/balance.go
+++ b/common/types/balance.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 
@@ -80,10 +81,13 @@ func (b Balance) Sub(n Balance) Balance {
 }
 
 // Div balances div
-func (b Balance) Div(n int64) Balance {
+func (b Balance) Div(n int64) (Balance, error) {
+	if n == 0 {
+		return ZeroBalance, errors.New("n should not be zero")
+	}
 	div := b.Int64() / n
 	b1 := new(big.Int).SetInt64(div)
-	return Balance{b1}
+	return Balance{b1}, nil
 }
 
 //Compare two balances

--- a/common/types/balance_test.go
+++ b/common/types/balance_test.go
@@ -157,6 +157,13 @@ func TestBalance_Add(t *testing.T) {
 
 func TestBalance_Div(t *testing.T) {
 	bb1 := Balance{big.NewInt(10000)}
-	bb2 := bb1.Div(2)
-	t.Log("bb1,bb2: ", bb1, bb2)
+	bb2, err := bb1.Div(2)
+	if err != nil {
+		t.Fatal("err should be nil")
+	}
+	bb3, err := bb1.Div(0)
+	if err == nil {
+		t.Fatal("err should not be nil")
+	}
+	t.Log("bb1,bb2: ", bb1, bb2, bb3)
 }

--- a/common/types/balance_test.go
+++ b/common/types/balance_test.go
@@ -154,3 +154,9 @@ func TestBalance_Add(t *testing.T) {
 	bb2 := Balance{big.NewInt(12000)}
 	t.Log("bb1+bb2: ", bb1.Add(bb2))
 }
+
+func TestBalance_Div(t *testing.T) {
+	bb1 := Balance{big.NewInt(10000)}
+	bb2 := bb1.Div(2)
+	t.Log("bb1,bb2: ", bb1, bb2)
+}


### PR DESCRIPTION

Signed-off-by: wenchao <659672152@qq.com>

### Proposed changes in this pull request
- use online representation of 50% of total weight as a consensus threshold
- fix #119 

_Please put an `x` against the checkboxes._  

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
