### PR TITLE
fix: default rpc public modules is nil

### DIFF
--- a/config/config_manager_test.go
+++ b/config/config_manager_test.go
@@ -152,6 +152,10 @@ func TestCfgManager_Load(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg2.P2P.Discovery.MDNSEnabled {
-		t.Fatal("migration error")
+		t.Fatal("migration p2p error")
+	}
+
+	if cfg2.RPC.PublicModules == nil {
+		t.Fatal("migration rpc error")
 	}
 }

--- a/config/config_v2.go
+++ b/config/config_v2.go
@@ -67,6 +67,7 @@ func DefaultConfigV2(dir string) (*ConfigV2, error) {
 		return nil, err
 	}
 	var cfg ConfigV2
+	modules := []string{"qlcclassic", "ledger", "account", "net", "util", "wallet", "mintage", "contract", "sms"}
 	if goqlc.MAINNET {
 		cfg = ConfigV2{
 			Version:             2,
@@ -85,6 +86,7 @@ func DefaultConfigV2(dir string) (*ConfigV2, error) {
 				WSEndpoint:       "tcp4://0.0.0.0:9736",
 				IPCEnabled:       true,
 				IPCEndpoint:      defaultIPCEndpoint(),
+				PublicModules:    modules,
 			},
 			P2P: &P2PConfigV2{
 				BootNodes: []string{
@@ -120,6 +122,7 @@ func DefaultConfigV2(dir string) (*ConfigV2, error) {
 				WSEndpoint:       "tcp4://0.0.0.0:19736",
 				IPCEnabled:       true,
 				IPCEndpoint:      defaultIPCEndpoint(),
+				PublicModules:    modules,
 			},
 			P2P: &P2PConfigV2{
 				BootNodes: []string{

--- a/config/defaults_test.go
+++ b/config/defaults_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018 QLC Chain Team
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+package config
+
+import (
+	"testing"
+)
+
+func Test_identityConfig(t *testing.T) {
+	pk, id, err := identityConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pk) == 0 {
+		t.Fatal("invalid pk")
+	}
+
+	if len(id) == 0 {
+		t.Fatal("invalid pk ")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Proposed changes in this pull request

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
N/A
