### PR TITLE
fix: migration rpc/p2p config to v2

### DIFF
--- a/config/config_manager.go
+++ b/config/config_manager.go
@@ -55,7 +55,7 @@ func (c *CfgManager) Load(migrations ...CfgMigrate) (*Config, error) {
 	for _, m := range migrations {
 		var err error
 		if version == m.StartVersion() {
-			fmt.Printf("migration cfg from %d to %d\n", m.StartVersion(), m.EndVersion())
+			fmt.Printf("migration cfg from v%d to v%d\n", m.StartVersion(), m.EndVersion())
 			bytes, version, err = m.Migration(bytes, version)
 			if err != nil {
 				fmt.Println(err)
@@ -80,7 +80,7 @@ func (c *CfgManager) Load(migrations ...CfgMigrate) (*Config, error) {
 }
 
 func (c *CfgManager) createAndSave() error {
-	cfg, err := DefaultConfigV2(c.cfgPath)
+	cfg, err := DefaultConfig(c.cfgPath)
 	if err != nil {
 		return err
 	}

--- a/config/config_v1.go
+++ b/config/config_v1.go
@@ -168,8 +168,8 @@ func DefaultConfigV1(dir string) (*ConfigV1, error) {
 			},
 			P2P: &P2PConfigV1{
 				BootNodes: []string{
-					"/ip4/47.244.138.61/tcp/19734/ipfs/QmdFSukPUMF3t1JxjvTo14SEEb5JV9JBT6PukGRo6A2g4f",
-					"/ip4/47.75.145.146/tcp/19734/ipfs/QmW9ocg4fRjckCMQvRNYGyKxQd6GiutAY4HBRxMrGrZRfc",
+					"/ip4/47.103.40.20/tcp/19734/ipfs/QmdFSukPUMF3t1JxjvTo14SEEb5JV9JBT6PukGRo6A2g4f",
+					"/ip4/47.112.112.138/tcp/19734/ipfs/QmW9ocg4fRjckCMQvRNYGyKxQd6GiutAY4HBRxMrGrZRfc",
 				},
 				Listen:       "/ip4/0.0.0.0/tcp/19734",
 				SyncInterval: 120,

--- a/config/config_v2.go
+++ b/config/config_v2.go
@@ -126,8 +126,8 @@ func DefaultConfigV2(dir string) (*ConfigV2, error) {
 			},
 			P2P: &P2PConfigV2{
 				BootNodes: []string{
-					"/ip4/47.244.138.61/tcp/19734/ipfs/QmdFSukPUMF3t1JxjvTo14SEEb5JV9JBT6PukGRo6A2g4f",
-					"/ip4/47.75.145.146/tcp/19734/ipfs/QmW9ocg4fRjckCMQvRNYGyKxQd6GiutAY4HBRxMrGrZRfc",
+					"/ip4/47.103.40.20/tcp/19734/ipfs/QmdFSukPUMF3t1JxjvTo14SEEb5JV9JBT6PukGRo6A2g4f",
+					"/ip4/47.112.112.138/tcp/19734/ipfs/QmW9ocg4fRjckCMQvRNYGyKxQd6GiutAY4HBRxMrGrZRfc",
 				},
 				Listen:       "/ip4/0.0.0.0/tcp/19734",
 				SyncInterval: 120,

--- a/config/migration_v1_v2.go
+++ b/config/migration_v1_v2.go
@@ -31,6 +31,22 @@ func (m *MigrationV1ToV2) Migration(data []byte, version int) ([]byte, int, erro
 	}
 
 	cfg2.AutoGenerateReceive = cfg1.AutoGenerateReceive
+	cfg2.PerformanceEnabled = cfg1.PerformanceTest.Enabled
+	// p2p
+	cfg2.P2P.BootNodes = cfg1.P2P.BootNodes
+	cfg2.P2P.Listen = cfg1.P2P.Listen
+	cfg2.P2P.SyncInterval = cfg1.P2P.SyncInterval
+	cfg2.P2P.Discovery.Limit = cfg1.Discovery.Limit
+	cfg2.P2P.Discovery.DiscoveryInterval = cfg1.Discovery.DiscoveryInterval
+	cfg2.P2P.Discovery.MDNSInterval = cfg1.Discovery.MDNS.Interval
+	cfg2.P2P.ID.PeerID = cfg1.ID.PeerID
+	cfg2.P2P.ID.PrivKey = cfg1.ID.PrivKey
+
+	//rpc
+	cfg2.RPC.HTTPEndpoint = cfg1.RPC.HTTPEndpoint
+	cfg2.RPC.HTTPCors = cfg1.RPC.HTTPCors
+	cfg2.RPC.IPCEndpoint = cfg1.RPC.IPCEndpoint
+	cfg2.RPC.WSEndpoint = cfg1.RPC.WSEndpoint
 
 	bytes, err := json.Marshal(cfg2)
 	return bytes, m.endVersion, err


### PR DESCRIPTION
- fix test net boot nodes
- migration rpc endpoint config to v2
- migration all p2p config to v2

Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
N/A
