### PR TITLE
fix: parseInt on 32bit OS

### DIFF
--- a/common/types/balance.go
+++ b/common/types/balance.go
@@ -151,7 +151,7 @@ func (b Balance) MarshalText() ([]byte, error) {
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 func (b *Balance) UnmarshalText(text []byte) error {
 	s := util.TrimQuotes(string(text))
-	_, err := strconv.Atoi(s)
+	_, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Type
- [x] Bug fix #353
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
N/A