### PR TITLE
refactor: simplified rewards contract RPC interface

### DIFF
--- a/rpc/api/rewards_test.go
+++ b/rpc/api/rewards_test.go
@@ -102,6 +102,10 @@ func TestRewardsApi_GetRewardData(t *testing.T) {
 	t.Log(util.ToIndentString(param))
 	t.Log(sign.String())
 
+	if isAirdropRewards := api.IsAirdropRewards(blk.Data); !isAirdropRewards {
+		t.Fatal("invalid data type")
+	}
+
 	vmContext := vmstore.NewVMContext(l)
 	err = api.rewards.DoSend(vmContext, blk)
 	if err != nil {
@@ -180,6 +184,10 @@ func TestRewardsApi_GetConfidantRewordsRewardData(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		t.Log(util.ToIndentString(blk))
+	}
+
+	if isAirdrop := api.IsAirdropRewards(blk.Data); isAirdrop {
+		t.Fatal("invalid block data")
 	}
 
 	vmContext := vmstore.NewVMContext(l)

--- a/vm/contract/abi/abi_rewards_test.go
+++ b/vm/contract/abi/abi_rewards_test.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2019 QLC Chain Team
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+package abi
+
+import (
+	"encoding/hex"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/qlcchain/go-qlc/common/types"
+	"github.com/qlcchain/go-qlc/common/util"
+	"github.com/qlcchain/go-qlc/config"
+	"github.com/qlcchain/go-qlc/crypto/random"
+	"github.com/qlcchain/go-qlc/ledger"
+	"github.com/qlcchain/go-qlc/mock"
+	"github.com/qlcchain/go-qlc/vm/vmstore"
+)
+
+func setupTestCase(t *testing.T) (func(t *testing.T), *ledger.Ledger) {
+	t.Parallel()
+
+	dir := filepath.Join(config.QlcTestDataDir(), "rewards", uuid.New().String())
+	_ = os.RemoveAll(dir)
+	l := ledger.NewLedger(dir)
+
+	return func(t *testing.T) {
+		//err := l.Store.Erase()
+		err := l.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		//CloseLedger()
+		err = os.RemoveAll(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}, l
+}
+
+func TestGetRewardsDetail(t *testing.T) {
+	teardownTestCase, l := setupTestCase(t)
+	defer teardownTestCase(t)
+
+	vmContext := vmstore.NewVMContext(l)
+
+	data := mockRewards(4, Rewards)
+
+	for _, md := range data {
+		key := GetRewardsKey(md.Param.Id[:], md.Param.TxHeader[:], md.Param.RxHeader[:])
+		if data, err := RewardsABI.PackVariable(VariableNameRewards, md.Info.Type, md.Info.From, md.Info.To,
+			md.Info.TxHeader, md.Info.RxHeader, md.Info.Amount); err == nil {
+			if err := vmContext.SetStorage(types.RewardsAddress[:], key, data); err != nil {
+				t.Error(err)
+			} else {
+				//t.Log(util.ToIndentString(md))
+				//t.Log(hex.EncodeToString(key))
+				//t.Log(hex.EncodeToString(data))
+			}
+		} else {
+			t.Fatal(err)
+		}
+	}
+	err := vmContext.SaveStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("prepare data successful")
+
+	txId := hex.EncodeToString(data[0].Param.Id[:])
+	t.Log("query ", txId)
+	infos, err := GetRewardsDetail(vmContext, txId)
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		total := new(big.Int)
+		for _, value := range infos {
+			total.Add(total, value.Amount)
+			t.Log("find ", util.ToIndentString(value))
+		}
+
+		rewards, err := GetTotalRewards(vmContext, txId)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if rewards.Cmp(total) != 0 {
+			t.Fatal("invalid total", rewards, total)
+		}
+	}
+
+}
+
+func TestGetConfidantDetail(t *testing.T) {
+	teardownTestCase, l := setupTestCase(t)
+	defer teardownTestCase(t)
+
+	vmContext := vmstore.NewVMContext(l)
+
+	data := mockRewards(4, Confidant)
+
+	for _, md := range data {
+		key := GetConfidantKey(md.Param.Beneficial, md.Param.Id[:], md.Param.TxHeader[:], md.Param.RxHeader[:])
+		if data, err := RewardsABI.PackVariable(VariableNameRewards, md.Info.Type, md.Info.From, md.Info.To,
+			md.Info.TxHeader, md.Info.RxHeader, md.Info.Amount); err == nil {
+			if err := vmContext.SetStorage(types.RewardsAddress[:], key, data); err != nil {
+				t.Error(err)
+			} else {
+				t.Log(util.ToIndentString(md))
+				t.Log(hex.EncodeToString(key))
+				t.Log(hex.EncodeToString(data))
+			}
+		} else {
+			t.Fatal(err)
+		}
+	}
+	err := vmContext.SaveStorage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("prepare data successful")
+	rxAddress := data[0].Param.Beneficial
+	t.Log("query ", rxAddress.String())
+	infos, err := GetConfidantRewordsDetail(vmContext, rxAddress)
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		for k, values := range infos {
+			for idx, v := range values {
+				t.Logf("%s: %d==>%v", k, idx, v)
+			}
+		}
+
+		rewards, err := GetConfidantRewords(vmContext, rxAddress)
+		if err != nil {
+			t.Fatal(err)
+		} else {
+			t.Log(util.ToIndentString(rewards))
+		}
+	}
+
+}
+
+type mockData struct {
+	Param *RewardsParam `json:"Param"`
+	Info  *RewardsInfo  `json:"info"`
+}
+
+func mockRewards(count int, t uint8) []*mockData {
+	var result []*mockData
+	txAddress := mock.Address()
+	txIds := []types.Hash{mock.Hash(), mock.Hash()}
+
+	for i := 0; i < count; i++ {
+		sign := make([]byte, types.SignatureSize)
+		_ = random.Bytes(sign)
+		signature, _ := types.BytesToSignature(sign)
+		i, _ := random.Intn(100)
+		param := &RewardsParam{
+			Id:         txIds[i%2],
+			Beneficial: mock.Address(),
+			TxHeader:   mock.Hash(),
+			RxHeader:   mock.Hash(),
+			Amount:     big.NewInt(int64(i + 1)),
+			Sign:       signature,
+		}
+
+		info := &RewardsInfo{
+			Type:     t,
+			From:     txAddress,
+			To:       param.Beneficial,
+			TxHeader: param.TxHeader,
+			RxHeader: param.RxHeader,
+			Amount:   param.Amount,
+		}
+
+		result = append(result, &mockData{
+			Param: param,
+			Info:  info,
+		})
+	}
+	return result
+}

--- a/vm/contract/contract.go
+++ b/vm/contract/contract.go
@@ -80,6 +80,19 @@ func GetChainContract(addr types.Address, methodSelector []byte) (ChainContract,
 	return nil, ok, nil
 }
 
+func GetChainContractName(addr types.Address, methodSelector []byte) (string, bool, error) {
+	p, ok := contractCache[addr]
+	if ok {
+		if method, err := p.abi.MethodById(methodSelector); err == nil {
+			_, ok := p.m[method.Name]
+			return method.Name, ok, nil
+		} else {
+			return "", ok, errors.New("abi: method not found")
+		}
+	}
+	return "", ok, nil
+}
+
 func IsChainContract(addr types.Address) bool {
 	if _, ok := contractCache[addr]; ok {
 		return true


### PR DESCRIPTION
- add test case for rewards contract
-  merge generate confidant/airdrop receive block into one

Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

_Please put an `x` against the checkboxes._  

### Type
- [] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
N/A
