### PR TITLE
fix: configParams bug when use default config name

### DIFF
--- a/cmd/server/commands/root.go
+++ b/cmd/server/commands/root.go
@@ -346,7 +346,12 @@ func run() {
 }
 
 func updateConfig(cfg *config.Config, cfgPathP string) error {
-	s := strings.Split(filepath.Base(cfgPathP), ".")
+	var s []string
+	if cfgPathP == "" {
+		s = strings.Split(config.QlcConfigFile, ".")
+	} else {
+		s = strings.Split(filepath.Base(cfgPathP), ".")
+	}
 	if len(s) != 2 {
 		return errors.New("split error")
 	}


### PR DESCRIPTION
Signed-off-by: wenchao <659672152@qq.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

_Please put an `x` against the checkboxes._  

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
