### PR TITLE
fix: `ledger_pendings` does not return data when error occurs

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -2247,7 +2247,7 @@ func (l *Ledger) GenerateReceiveBlock(sendBlock *types.StateBlock, prk ed25519.P
 		}
 	}
 
-	if prk != nil {
+	if prk != nil && acc != nil {
 		sb.Signature = acc.Sign(sb.GetHash())
 		sb.Work = l.generateWork(sb.Root())
 	}

--- a/rpc/api/ledger.go
+++ b/rpc/api/ledger.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/qlcchain/go-qlc/common/util"
 	"sort"
 
 	"github.com/qlcchain/go-qlc/common"
@@ -688,15 +689,17 @@ func (l *LedgerApi) Pendings() ([]*APIPending, error) {
 		tokenName := token.TokenName
 		blk, err := l.ledger.GetStateBlock(pendingKey.Hash)
 		if err != nil {
-			return err
+			l.logger.Errorf("can not fetch block from %s, %s", util.ToString(pendingKey), util.ToString(pendingInfo))
+		} else {
+			ap := APIPending{
+				PendingKey:  pendingKey,
+				PendingInfo: pendingInfo,
+				TokenName:   tokenName,
+				Timestamp:   blk.Timestamp,
+			}
+			aps = append(aps, &ap)
 		}
-		ap := APIPending{
-			PendingKey:  pendingKey,
-			PendingInfo: pendingInfo,
-			TokenName:   tokenName,
-			Timestamp:   blk.Timestamp,
-		}
-		aps = append(aps, &ap)
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
### Proposed changes in this pull request

- fix `ledger_pendings` interface
- fix `GenerateReceiveBlock` possible NPE

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
N/A
