### PR TITLE
fix: verify exist data when generate rewards data

### DIFF
--- a/vm/contract/rewards.go
+++ b/vm/contract/rewards.go
@@ -10,7 +10,6 @@ package contract
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/qlcchain/go-qlc/common"
 	"github.com/qlcchain/go-qlc/common/types"
 	cabi "github.com/qlcchain/go-qlc/vm/contract/abi"
@@ -194,10 +193,17 @@ func generate(ctx *vmstore.VMContext, signed, unsigned string, block *types.Stat
 			//already exist
 			if len(data) > 0 {
 				if rewardsInfo, err := cabi.ParseRewardsInfo(data); err == nil {
-					if rewardsInfo.TxHeader != info.TxHeader || rewardsInfo.RxHeader != info.RxHeader ||
-						rewardsInfo.Amount.Cmp(info.Amount) != 0 || rewardsInfo.Type != info.Type ||
+					if rewardsInfo.Amount.Cmp(info.Amount) != 0 || rewardsInfo.Type != info.Type ||
+						//rewardsInfo.TxHeader != info.TxHeader || rewardsInfo.RxHeader != info.RxHeader ||
 						rewardsInfo.From != info.From || rewardsInfo.To != info.To {
-						return nil, errors.New("invalid saved confidant data")
+						return nil, fmt.Errorf("invalid saved confidant data: txHeader(%s,%s,%t);"+
+							" rxHeader(%s,%s,%t); amount(%s,%s,%t); type(%d,%d,%t); from(%s,%s,%t); to(%s,%s,%t)",
+							rewardsInfo.TxHeader, info.TxHeader, rewardsInfo.TxHeader == info.TxHeader,
+							rewardsInfo.RxHeader, info.RxHeader, rewardsInfo.RxHeader == info.RxHeader,
+							rewardsInfo.Amount, info.Amount, rewardsInfo.Amount.Cmp(info.Amount) == 0,
+							rewardsInfo.Type, info.Type, rewardsInfo.Type == info.Type,
+							rewardsInfo.From, info.From, rewardsInfo.From == info.From,
+							rewardsInfo.To, info.To, rewardsInfo.To == info.To)
 					}
 				} else {
 					return nil, err


### PR DESCRIPTION
Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Proposed changes in this pull request

fix verify exist rewards block data

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information

N/A
