### PR TITLE
fix: don't process transaction when node offline

### DIFF
--- a/p2p/node.go
+++ b/p2p/node.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"time"
+
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 
 	"github.com/qlcchain/go-qlc/p2p/pubsub"
 

--- a/p2p/stream.go
+++ b/p2p/stream.go
@@ -1,8 +1,10 @@
 package p2p
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"sync"
 	"time"
 
@@ -40,6 +42,10 @@ type Stream struct {
 	normalPriorityMessageChan chan *QlcMessage
 	lowPriorityMessageChan    chan *QlcMessage
 	rtt                       time.Duration
+	pingCtx                   context.Context
+	pingCancel                context.CancelFunc
+	pingTimeoutTimes          int
+	pingResult                <-chan ping.Result
 }
 
 // NewStream return a new Stream
@@ -53,6 +59,7 @@ func NewStreamFromPID(pid peer.ID, node *QlcNode) *Stream {
 }
 
 func newStreamInstance(pid peer.ID, addr ma.Multiaddr, stream network.Stream, node *QlcNode) *Stream {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Stream{
 		pid:                       pid,
 		addr:                      addr,
@@ -63,6 +70,9 @@ func newStreamInstance(pid peer.ID, addr ma.Multiaddr, stream network.Stream, no
 		highPriorityMessageChan:   make(chan *QlcMessage, 20*1024),
 		normalPriorityMessageChan: make(chan *QlcMessage, 20*1024),
 		lowPriorityMessageChan:    make(chan *QlcMessage, 20*1024),
+		pingCtx:                   ctx,
+		pingCancel:                cancel,
+		pingTimeoutTimes:          0,
 	}
 }
 
@@ -82,7 +92,6 @@ func (s *Stream) Connect() error {
 	//s.node.logger.Info("connect success to :", s.pid.Pretty())
 	s.stream = stream
 	s.addr = stream.Conn().RemoteMultiaddr()
-
 	return nil
 }
 
@@ -220,6 +229,7 @@ func (s *Stream) close() error {
 
 	// quit.
 	s.quitWriteCh <- true
+	s.pingCancel()
 	// close stream.
 	if s.stream != nil {
 		if err := s.stream.Close(); err != nil {
@@ -260,10 +270,10 @@ func (s *Stream) Write(data []byte) error {
 	}
 
 	// at least 5kb/s to write message
-	deadline := time.Now().Add(time.Duration(len(data)/1024/5+1) * time.Second)
-	if err := s.stream.SetWriteDeadline(deadline); err != nil {
-		return err
-	}
+	//deadline := time.Now().Add(time.Duration(len(data)/1024/5+1) * time.Second)
+	//if err := s.stream.SetWriteDeadline(deadline); err != nil {
+	//	return err
+	//}
 
 	n, err := s.stream.Write(data)
 	if err != nil {

--- a/p2p/stream.go
+++ b/p2p/stream.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"sync"
 	"time"
+
+	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/rpc/api/ledger.go
+++ b/rpc/api/ledger.go
@@ -837,6 +837,11 @@ func (l *LedgerApi) Process(block *types.StateBlock) (types.Hash, error) {
 	if ss := l.syncState.Load().(common.SyncState); ss != common.SyncDone {
 		return types.ZeroHash, errors.New("pov sync is not finished, please check it")
 	}
+	p := make(map[string]string)
+	l.eb.Publish(common.EventPeersInfo, p)
+	if len(p) == 0 {
+		return types.ZeroHash, errors.New("no peer connect,please check it")
+	}
 	lv := l.getProcessLock(block.Address, block.Token)
 	lv.mutex.Lock()
 	defer func() {

--- a/rpc/api/ledger_test.go
+++ b/rpc/api/ledger_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -84,8 +83,7 @@ func TestLedger_GetBlockCacheLock(t *testing.T) {
 	_, _ = ledgerApi.Process(sb)
 	addr2, _ := types.HexToAddress("qlc_1gnggt8b6cwro3b4z9gootipykqd6x5gucfd7exsi4xqkryiijciegfhon4u")
 	_ = ledgerApi.getProcessLock(addr2, chainToken)
-	fmt.Println(ledgerApi.processLock.Len())
-	if ledgerApi.processLock.Len() != 1000 {
+	if ledgerApi.processLock.Len() != 1001 {
 		t.Fatal("get error when delete idle lock")
 	}
 }


### PR DESCRIPTION
- feat: it is forbidden to send a transaction when there is no node connection.
- refactor ping service.
- fix #667 

Signed-off-by: wenchao <659672152@qq.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

_Please put an `x` against the checkboxes._  

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
