### PR TITLE
fix: token pointer in ledger cache cause account info error

### DIFF
--- a/common/types/account.go
+++ b/common/types/account.go
@@ -9,6 +9,7 @@ package types
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/qlcchain/go-qlc/crypto/ed25519"
@@ -132,6 +133,28 @@ func (am *AccountMeta) Deserialize(text []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (am *AccountMeta) Clone() *AccountMeta {
+	clone := AccountMeta{}
+	clone.Address = am.Address
+	clone.CoinBalance = am.CoinBalance
+	clone.CoinNetwork = am.CoinNetwork
+	clone.CoinVote = am.CoinVote
+	clone.CoinOracle = am.CoinOracle
+	clone.CoinStorage = am.CoinStorage
+	for _, tm := range am.Tokens {
+		t := TokenMeta{}
+		bytes, _ := tm.MarshalMsg(nil)
+		t.UnmarshalMsg(bytes)
+		clone.Tokens = append(clone.Tokens, &t)
+	}
+	return &clone
+}
+
+func (am *AccountMeta) String() string {
+	bytes, _ := json.Marshal(am)
+	return string(bytes)
 }
 
 // NewAccount creates a new account with the given private key.

--- a/common/types/account_test.go
+++ b/common/types/account_test.go
@@ -9,6 +9,9 @@ package types
 
 import (
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/qlcchain/go-qlc/crypto/random"
@@ -54,5 +57,50 @@ func TestNewAccount(t *testing.T) {
 		} else {
 			t.Log(account.String())
 		}
+	}
+}
+
+var testAccountMeta = `{
+    "account": "qlc_3hw8s1zubhxsykfsq5x7kh6eyibas9j3ga86ixd7pnqwes1cmt9mqqrngap4",
+    "coinBalance": "17966873799999699",
+    "vote": "0",
+    "network": "0",
+    "storage": "0",
+    "oracle": "0",
+    "representative": "qlc_3hw8s1zubhxsykfsq5x7kh6eyibas9j3ga86ixd7pnqwes1cmt9mqqrngap4",
+    "tokens": [
+      {
+        "type": "a7e8fa30c063e96a489a47bc43909505bd86735da4a109dca28be936118a8582",
+        "header": "9f5fecaee7faca0ee389b2e93447ba14c682dd02612503ef6117203d45944a19",
+        "representative": "qlc_3hw8s1zubhxsykfsq5x7kh6eyibas9j3ga86ixd7pnqwes1cmt9mqqrngap4",
+        "open": "5594c690c3618a170a77d2696688f908efec4da2b94363fcb96749516307031d",
+        "balance": "17966873799999699",
+        "account": "qlc_3hw8s1zubhxsykfsq5x7kh6eyibas9j3ga86ixd7pnqwes1cmt9mqqrngap4",
+        "modified": 1572522444,
+        "blockCount": 233,
+        "tokenName": "QLC",
+        "pending": "0"
+      }
+    ]
+  }
+	`
+
+func TestAccountMeta_Clone(t *testing.T) {
+	b := AccountMeta{}
+	err := json.Unmarshal([]byte(testAccountMeta), &b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log(b.String())
+	b1 := b.Clone()
+	fmt.Printf("%p ", b.Tokens[0])
+	fmt.Printf("%p ", b1.Tokens[0])
+
+	if reflect.DeepEqual(b, b1) {
+		t.Fatal("invalid clone")
+	}
+
+	if b.String() != b1.String() {
+		t.Fatal("invalid clone ", b.String(), b1.String())
 	}
 }

--- a/ledger/ledger_account_cache.go
+++ b/ledger/ledger_account_cache.go
@@ -1,9 +1,11 @@
 package ledger
 
-import "github.com/qlcchain/go-qlc/common/types"
+import (
+	"github.com/qlcchain/go-qlc/common/types"
+)
 
 func (c *Cache) UpdateAccountMetaUnConfirmed(am *types.AccountMeta) error {
-	return c.unConfirmedAccount.Set(am.Address, *am)
+	return c.unConfirmedAccount.Set(am.Address, am.Clone())
 }
 
 func (c *Cache) GetAccountMetaUnConfirmed(address types.Address) (*types.AccountMeta, error) {
@@ -11,8 +13,8 @@ func (c *Cache) GetAccountMetaUnConfirmed(address types.Address) (*types.Account
 	if err != nil {
 		return nil, err
 	}
-	am := v.(types.AccountMeta)
-	return &am, nil
+	am := v.(*types.AccountMeta)
+	return am.Clone(), nil
 }
 
 func (c *Cache) DeleteAccountMetaUnConfirmed(address types.Address) {
@@ -20,7 +22,7 @@ func (c *Cache) DeleteAccountMetaUnConfirmed(address types.Address) {
 }
 
 func (c *Cache) UpdateAccountMetaConfirmed(am *types.AccountMeta) error {
-	return c.confirmedAccount.Set(am.Address, *am)
+	return c.confirmedAccount.Set(am.Address, am.Clone())
 }
 
 func (c *Cache) GetAccountMetaConfirmed(address types.Address) (*types.AccountMeta, error) {
@@ -28,8 +30,8 @@ func (c *Cache) GetAccountMetaConfirmed(address types.Address) (*types.AccountMe
 	if err != nil {
 		return nil, err
 	}
-	am := v.(types.AccountMeta)
-	return &am, nil
+	am := v.(*types.AccountMeta)
+	return am.Clone(), nil
 }
 
 func (c *Cache) DeleteAccountMetaConfirmed(address types.Address) {

--- a/ledger/ledger_account_test.go
+++ b/ledger/ledger_account_test.go
@@ -21,8 +21,24 @@ func TestLedger_AddAccountMeta(t *testing.T) {
 	teardownTestCase, l := setupTestCase(t)
 	defer teardownTestCase(t)
 	am := addAccountMeta(t, l)
-	if _, err := l.cache.GetAccountMetaConfirmed(am.Address); err != nil {
+	a, err := l.cache.GetAccountMetaConfirmed(am.Address)
+	if err != nil {
 		t.Fatal(err)
+	}
+	amount := types.Balance{Int: big.NewInt(50)}
+	a.CoinVote = amount
+	a.Tokens[0].Balance = amount
+	b, err := l.cache.GetAccountMetaConfirmed(am.Address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.CoinVote.Equal(amount) {
+		t.Fatal()
+	}
+	for _, tm := range b.Tokens {
+		if tm.Type == a.Tokens[0].Type && tm.Balance.Equal(amount) {
+			t.Fatal()
+		}
 	}
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- token pointer in ledger cache cause account info error

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
