### PR TITLE
fix: pubsub notify data should same with api block

### DIFF
--- a/rpc/api/pov.go
+++ b/rpc/api/pov.go
@@ -1442,7 +1442,9 @@ func (api *PovApi) NewBlock(ctx context.Context) (*rpc.Subscription, error) {
 						}
 
 						header := block.GetHeader()
-						err := notifier.Notify(subscription.ID, header)
+						apiHdr := &PovApiHeader{PovHeader: header}
+						api.fillHeader(apiHdr)
+						err := notifier.Notify(subscription.ID, apiHdr)
 						if err != nil {
 							api.logger.Errorf("notify pov header %d/%s error: %s",
 								err, header.GetHeight(), header.GetHash())


### PR DESCRIPTION
### Proposed changes in this pull request
pubsub notify data should same with api block.

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
