### PR TITLE
feat: pubsub notify data same with api accountmeta

### DIFF
--- a/ledger/ledger_pending.go
+++ b/ledger/ledger_pending.go
@@ -255,17 +255,13 @@ func (l *Ledger) PendingAmount(address types.Address, token types.Hash, txns ...
 	txn, flag := l.getTxn(false, txns...)
 	defer l.releaseTxn(txn, flag)
 
-	pendingKeys, err := l.TokenPending(address, token)
+	pendingInfos, err := l.TokenPendingInfo(address, token)
 	if err != nil {
 		return types.ZeroBalance, err
 	}
 	pendingAmount := types.ZeroBalance
-	for _, key := range pendingKeys {
-		pendinginfo, err := l.GetPending(key)
-		if err != nil {
-			return types.ZeroBalance, err
-		}
-		pendingAmount = pendingAmount.Add(pendinginfo.Amount)
+	for _, info := range pendingInfos {
+		pendingAmount = pendingAmount.Add(info.Amount)
 	}
 	if err := l.cache.AddAccountPending(address, token, pendingAmount); err != nil {
 		return types.ZeroBalance, err


### PR DESCRIPTION
### Proposed changes in this pull request

- pubsub notify data same with api accountmeta

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
