### PR TITLE
fix: pov verify producer shoud use current header miner

### DIFF
--- a/consensus/pov/consensus_pov.go
+++ b/consensus/pov/consensus_pov.go
@@ -15,6 +15,7 @@ type PovConsensusChainReader interface {
 	RelativeAncestor(header *types.PovHeader, distance uint64) *types.PovHeader
 	GetStateTrie(stateHash *types.Hash) *trie.Trie
 	GetAccountState(trie *trie.Trie, address types.Address) *types.PovAccountState
+	GetRepState(trie *trie.Trie, address types.Address) *types.PovRepState
 }
 
 type ConsensusPov interface {

--- a/consensus/pov/pov_pow.go
+++ b/consensus/pov/pov_pow.go
@@ -87,16 +87,9 @@ func (c *ConsensusPow) verifyProducer(header *types.PovHeader) error {
 		return errors.New("failed to get previous state tire")
 	}
 
-	rsKey := types.PovCreateRepStateKey(prevHeader.GetMinerAddr())
-	rsVal := prevTrie.GetValue(rsKey)
-	if len(rsVal) == 0 {
-		return errors.New("failed to get rep state value")
-	}
-
-	rs := types.NewPovRepState()
-	err := rs.Deserialize(rsVal)
-	if err != nil {
-		return errors.New("failed to deserialize rep state value")
+	rs := c.chainR.GetRepState(prevTrie, header.GetMinerAddr())
+	if rs == nil {
+		return errors.New("failed to get rep state")
 	}
 
 	if rs.Vote.Compare(common.PovMinerPledgeAmountMin) == types.BalanceCompSmaller {

--- a/consensus/pov/pov_verifier_test.go
+++ b/consensus/pov/pov_verifier_test.go
@@ -57,6 +57,10 @@ func (c *mockPovVerifierChainReader) GetAccountState(trie *trie.Trie, address ty
 	return nil
 }
 
+func (c *mockPovVerifierChainReader) GetRepState(trie *trie.Trie, address types.Address) *types.PovRepState {
+	return nil
+}
+
 func (c *mockPovVerifierChainReader) CalcBlockReward(header *types.PovHeader) (types.Balance, types.Balance) {
 	return types.ZeroBalance, types.ZeroBalance
 }
@@ -80,6 +84,10 @@ func (c *mockPovConsensusChainReader) GetStateTrie(stateHash *types.Hash) *trie.
 }
 
 func (c *mockPovConsensusChainReader) GetAccountState(trie *trie.Trie, address types.Address) *types.PovAccountState {
+	return nil
+}
+
+func (c *mockPovConsensusChainReader) GetRepState(trie *trie.Trie, address types.Address) *types.PovRepState {
 	return nil
 }
 

--- a/miner/pov_worker.go
+++ b/miner/pov_worker.go
@@ -387,8 +387,11 @@ func (w *PovWorker) checkMinerPledge(minerAddr types.Address) error {
 
 	if latestBlock.GetHeight() >= (common.PovMinerVerifyHeightStart - 1) {
 		prevStateHash := latestBlock.GetStateHash()
-		stateTrie := w.GetChain().GetStateTrie(&prevStateHash)
-		rs := w.GetChain().GetRepState(stateTrie, minerAddr)
+		prevTrie := w.GetChain().GetStateTrie(&prevStateHash)
+		if prevTrie == nil {
+			return errors.New("miner pausing for get previous state tire failed")
+		}
+		rs := w.GetChain().GetRepState(prevTrie, minerAddr)
 		if rs == nil {
 			return errors.New("miner pausing for account state not exist")
 		}


### PR DESCRIPTION
### Proposed changes in this pull request
pov verify producer shoud use current header miner.

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
