### PR TITLE
fix: pov should use event broadcast

### DIFF
--- a/consensus/pov/pov_chain.go
+++ b/consensus/pov/pov_chain.go
@@ -294,6 +294,7 @@ func (bc *PovBlockChain) onMinerDayStatTimer() {
 				minerStat.LastHeight = header.GetHeight()
 			} else {
 				minerStat.FirstHeight = header.GetHeight()
+				minerStat.LastHeight = header.GetHeight()
 				minerStat.IsMiner = true
 			}
 

--- a/consensus/pov/pov_impl.go
+++ b/consensus/pov/pov_impl.go
@@ -252,7 +252,7 @@ func (pov *PoVEngine) onRecvPovBlock(block *types.PovBlock, from types.PovBlockF
 	err := pov.AddBlock(block, from, msgPeer)
 	if err == nil {
 		if from == types.PovBlockFromRemoteBroadcast {
-			pov.eb.Publish(common.EventSendMsgToPeers, p2p.PovPublishReq, block, msgPeer)
+			pov.eb.Publish(common.EventBroadcast, p2p.PovPublishReq, block)
 		}
 	}
 


### PR DESCRIPTION
### Proposed changes in this pull request
pov should use event broadcast, as p2p service is using libp2p pubsub.

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
