### PR TITLE
fix: delete the useless block in the unchecked 

### DIFF
--- a/consensus/dpos/active_transactions.go
+++ b/consensus/dpos/active_transactions.go
@@ -175,6 +175,7 @@ func (act *ActiveTrx) checkVotes() {
 			dps.logger.Warnf("block[%s] was not confirmed after %d times resend", hash, confirmReqMaxTimes)
 			act.roots.Delete(el.vote.id)
 			el.cleanBlockInfo()
+			act.dps.lv.RollbackUnchecked(hash)
 
 			if dps.isReceivedFrontier(hash) {
 				dps.logger.Warn("sync finish abnormally because of frontier not confirmed")

--- a/consensus/dpos/dpos_impl.go
+++ b/consensus/dpos/dpos_impl.go
@@ -1060,7 +1060,7 @@ func (dps *DPoS) calculateAckHash(va *protos.ConfirmAckBlock) (types.Hash, error
 }
 
 func (dps *DPoS) onRollback(hash types.Hash) {
-	dps.rollbackUncheckedFromDb(hash)
+	//dps.rollbackUncheckedFromDb(hash)
 
 	blk, err := dps.ledger.GetStateBlockConfirmed(hash)
 	if err == nil && blk.Type == types.Online {
@@ -1073,49 +1073,49 @@ func (dps *DPoS) onRollback(hash types.Hash) {
 	}
 }
 
-func (dps *DPoS) rollbackUncheckedFromDb(hash types.Hash) {
-	if blkLink, _, _ := dps.ledger.GetUncheckedBlock(hash, types.UncheckedKindLink); blkLink != nil {
-		err := dps.ledger.DeleteUncheckedBlock(hash, types.UncheckedKindLink)
-		if err != nil {
-			dps.logger.Errorf("Get err [%s] for hash: [%s] when delete UncheckedKindLink", err, blkLink.GetHash())
-		}
-	}
-
-	if blkPrevious, _, _ := dps.ledger.GetUncheckedBlock(hash, types.UncheckedKindPrevious); blkPrevious != nil {
-		err := dps.ledger.DeleteUncheckedBlock(hash, types.UncheckedKindPrevious)
-		if err != nil {
-			dps.logger.Errorf("Get err [%s] for hash: [%s] when delete UncheckedKindPrevious", err, blkPrevious.GetHash())
-		}
-	}
-
-	// gap token
-	blk, err := dps.ledger.GetStateBlock(hash)
-	if err != nil {
-		dps.logger.Errorf("get block error [%s]", hash)
-		return
-	}
-
-	if blk.GetType() == types.ContractReward {
-		input, err := dps.ledger.GetStateBlock(blk.GetLink())
-		if err != nil {
-			dps.logger.Errorf("dequeue get block link error [%s]", hash)
-			return
-		}
-
-		address := types.Address(input.GetLink())
-		if address == types.MintageAddress {
-			var param = new(cabi.ParamMintage)
-			if err := cabi.MintageABI.UnpackMethod(param, cabi.MethodNameMintage, input.GetData()); err == nil {
-				if blkToken, _, _ := dps.ledger.GetUncheckedBlock(param.TokenId, types.UncheckedKindTokenInfo); blkToken != nil {
-					err := dps.ledger.DeleteUncheckedBlock(param.TokenId, types.UncheckedKindTokenInfo)
-					if err != nil {
-						dps.logger.Errorf("Get err [%s] for hash: [%s] when delete UncheckedKindTokenInfo", err, blkToken.GetHash())
-					}
-				}
-			}
-		}
-	}
-}
+//func (dps *DPoS) rollbackUncheckedFromDb(hash types.Hash) {
+//	if blkLink, _, _ := dps.ledger.GetUncheckedBlock(hash, types.UncheckedKindLink); blkLink != nil {
+//		err := dps.ledger.DeleteUncheckedBlock(hash, types.UncheckedKindLink)
+//		if err != nil {
+//			dps.logger.Errorf("Get err [%s] for hash: [%s] when delete UncheckedKindLink", err, blkLink.GetHash())
+//		}
+//	}
+//
+//	if blkPrevious, _, _ := dps.ledger.GetUncheckedBlock(hash, types.UncheckedKindPrevious); blkPrevious != nil {
+//		err := dps.ledger.DeleteUncheckedBlock(hash, types.UncheckedKindPrevious)
+//		if err != nil {
+//			dps.logger.Errorf("Get err [%s] for hash: [%s] when delete UncheckedKindPrevious", err, blkPrevious.GetHash())
+//		}
+//	}
+//
+//	// gap token
+//	blk, err := dps.ledger.GetStateBlock(hash)
+//	if err != nil {
+//		dps.logger.Errorf("get block error [%s]", hash)
+//		return
+//	}
+//
+//	if blk.GetType() == types.ContractReward {
+//		input, err := dps.ledger.GetStateBlock(blk.GetLink())
+//		if err != nil {
+//			dps.logger.Errorf("dequeue get block link error [%s]", hash)
+//			return
+//		}
+//
+//		address := types.Address(input.GetLink())
+//		if address == types.MintageAddress {
+//			var param = new(cabi.ParamMintage)
+//			if err := cabi.MintageABI.UnpackMethod(param, cabi.MethodNameMintage, input.GetData()); err == nil {
+//				if blkToken, _, _ := dps.ledger.GetUncheckedBlock(param.TokenId, types.UncheckedKindTokenInfo); blkToken != nil {
+//					err := dps.ledger.DeleteUncheckedBlock(param.TokenId, types.UncheckedKindTokenInfo)
+//					if err != nil {
+//						dps.logger.Errorf("Get err [%s] for hash: [%s] when delete UncheckedKindTokenInfo", err, blkToken.GetHash())
+//					}
+//				}
+//			}
+//		}
+//	}
+//}
 
 func (dps *DPoS) getSeq(kind uint32) uint32 {
 	var seq, ackSeq uint32


### PR DESCRIPTION
delete the block in the unchecked that depends on the current block when the current block consensus times out to fix #749 

Signed-off-by: wenchao <659672152@qq.com>

### Proposed changes in this pull request
Explain the changes in this pull request in order to help the project maintainers understand the overall impact of it.

_Please put an `x` against the checkboxes._  

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
