### PR TITLE
fix: miner contract blocks need to be synchronized in order

### DIFF
--- a/consensus/dpos/dpos_impl.go
+++ b/consensus/dpos/dpos_impl.go
@@ -1272,6 +1272,8 @@ func (dps *DPoS) isRelatedOrderBlock(block *types.StateBlock) (bool, error) {
 		switch types.Address(block.GetLink()) {
 		case types.BlackHoleAddress:
 			return true, nil
+		case types.MinerAddress, types.RepAddress:
+			return true, nil
 		}
 	}
 	return false, nil


### PR DESCRIPTION
### Proposed changes in this pull request

- miner contract blocks need to be synchronized in order

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
