### PR TITLE
fix: update pov mainnet genesis to sha256d

### DIFF
--- a/common/genesis_pov.go
+++ b/common/genesis_pov.go
@@ -15,10 +15,10 @@ var (
             "version":0,
             "previous":"0000000000000000000000000000000000000000000000000000000000000000",
             "merkleRoot":"0ca279bf861acd7acb33bbc6c44471185ea88f4fad36fb3f973423b73aa9aa07",
-            "timestamp":1569024021,
+            "timestamp":1575590409,
             "bits":486604799,
-            "nonce":3776166188,
-            "hash":"f9b322a0b87057122ef30c780245614c90be780b68f0f1ae355b0b0e00000000",
+            "nonce":1908745832,
+            "hash":"92bafc7a0079ffd173c1228bbeb2bf95285df578bf1c7a9b5881b1a500000000",
             "height":0
         },
         "auxHdr":null,

--- a/common/genesis_pov.go
+++ b/common/genesis_pov.go
@@ -12,13 +12,13 @@ var (
 	jsonPovGenesis = `{
     "header":{
         "basHdr":{
-            "version":256,
+            "version":0,
             "previous":"0000000000000000000000000000000000000000000000000000000000000000",
             "merkleRoot":"0ca279bf861acd7acb33bbc6c44471185ea88f4fad36fb3f973423b73aa9aa07",
-            "timestamp":1569024018,
-            "bits":506640333,
-            "nonce":645962481,
-            "hash":"5e66d8b374409cdf3b94dad3e6d3854803077a654ce0f770311b6fa429395626",
+            "timestamp":1569024021,
+            "bits":486604799,
+            "nonce":3776166188,
+            "hash":"f9b322a0b87057122ef30c780245614c90be780b68f0f1ae355b0b0e00000000",
             "height":0
         },
         "auxHdr":null,

--- a/common/genesis_pov_test.go
+++ b/common/genesis_pov_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenesisPovBlock1(t *testing.T) {
-	expectHash, _ := types.NewHash("5e66d8b374409cdf3b94dad3e6d3854803077a654ce0f770311b6fa429395626")
+	expectHash, _ := types.NewHash("f9b322a0b87057122ef30c780245614c90be780b68f0f1ae355b0b0e00000000")
 
 	expectStateHash, _ := types.NewHash("1e78dcddbe569968e758251ada684d313104ca72285285e21cc381770fd3ee49")
 

--- a/common/genesis_pov_test.go
+++ b/common/genesis_pov_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGenesisPovBlock1(t *testing.T) {
-	expectHash, _ := types.NewHash("f9b322a0b87057122ef30c780245614c90be780b68f0f1ae355b0b0e00000000")
+	expectHash, _ := types.NewHash("92bafc7a0079ffd173c1228bbeb2bf95285df578bf1c7a9b5881b1a500000000")
 
 	expectStateHash, _ := types.NewHash("1e78dcddbe569968e758251ada684d313104ca72285285e21cc381770fd3ee49")
 


### PR DESCRIPTION
### Proposed changes in this pull request
update pov mainnet genesis to sha256d.

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
