### PR TITLE
fix: apply memory once when batch update blocks to sqlite

### DIFF
--- a/ledger/relation/relation_impl.go
+++ b/ledger/relation/relation_impl.go
@@ -317,12 +317,12 @@ func blockType(bs []blocksType) map[string]uint64 {
 }
 
 func (r *Relation) processBlocks() {
+	blocks := make([]*types.StateBlock, 0)
 	for {
 		select {
 		case <-r.ctx.Done():
 			return
 		case blk := <-r.addBlkChan:
-			blocks := make([]*types.StateBlock, 0)
 			blocks = append(blocks, blk)
 			if len(r.addBlkChan) > 0 {
 				for b := range r.addBlkChan {
@@ -345,6 +345,7 @@ func (r *Relation) processBlocks() {
 			if err != nil {
 				r.logger.Errorf("batch update blocks error: %s", err)
 			}
+			blocks = blocks[:0:0]
 		case blk := <-r.deleteBlkChan:
 			if err := r.DeleteBlock(blk); err != nil {
 				r.logger.Error(err)


### PR DESCRIPTION
### Proposed changes in this pull request

- apply memory once when batch update blocks to sqlite

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
