### PR TITLE
fix: add pov status to mintage api 

### DIFF
--- a/common/genesis.go
+++ b/common/genesis.go
@@ -85,6 +85,24 @@ func GasBlockHash() types.Hash {
 	return types.ZeroHash
 }
 
+func GasMintageBlock() types.StateBlock {
+	for _, v := range GenesisInfos {
+		if v.GasToken {
+			return v.GenesisMintageBlock
+		}
+	}
+	return types.StateBlock{}
+}
+
+func GasBlock() types.StateBlock {
+	for _, v := range GenesisInfos {
+		if v.GasToken {
+			return v.GenesisBlock
+		}
+	}
+	return types.StateBlock{}
+}
+
 // IsGenesis check block is chain token genesis
 func IsGenesisBlock(block *types.StateBlock) bool {
 	hash := block.GetHash()

--- a/ledger/relation/relation_impl.go
+++ b/ledger/relation/relation_impl.go
@@ -405,7 +405,7 @@ func (r *Relation) SetEvent() error {
 		case types.Tuple:
 			r.waitAddSyncBlocks(msg.First.(*types.StateBlock), msg.Second.(bool))
 		}
-	}))
+	}), r.eb)
 
 	return r.subscriber.Subscribe(topic.EventAddRelation, topic.EventAddSyncBlocks, topic.EventDeleteRelation)
 }

--- a/rpc/api/ledger.go
+++ b/rpc/api/ledger.go
@@ -1196,3 +1196,12 @@ func (l *LedgerAPI) NewPending(ctx context.Context, address types.Address) (*rpc
 		}()
 	})
 }
+
+func (l *LedgerAPI) GenesisBlocks() (map[string]types.StateBlock, error) {
+	genesisBlk := make(map[string]types.StateBlock)
+	genesisBlk["chain"] = common.GenesisBlock()
+	genesisBlk["chain-mintage"] = common.GenesisMintageBlock()
+	genesisBlk["gas"] = common.GasBlock()
+	genesisBlk["gas-mintage"] = common.GasMintageBlock()
+	return genesisBlk, nil
+}

--- a/rpc/api/mintage.go
+++ b/rpc/api/mintage.go
@@ -32,12 +32,13 @@ type MintageAPI struct {
 	cc       *chainctx.ChainContext
 }
 
-func NewMintageApi(l *ledger.Ledger) *MintageAPI {
+func NewMintageApi(cfgFile string, l *ledger.Ledger) *MintageAPI {
 	api := &MintageAPI{
 		l:        l,
 		mintage:  &contract.Mintage{},
 		withdraw: &contract.WithdrawMintage{},
 		logger:   log.NewLogger("api_mintage"),
+		cc:       chainctx.NewChainContext(cfgFile),
 	}
 	return api
 }

--- a/rpc/apis.go
+++ b/rpc/apis.go
@@ -54,7 +54,7 @@ func (r *RPC) getApi(apiModule string) rpc.API {
 		return rpc.API{
 			Namespace: "mintage",
 			Version:   "1.0",
-			Service:   api.NewMintageApi(r.ledger),
+			Service:   api.NewMintageApi(r.cfgFile, r.ledger),
 			Public:    true,
 		}
 	case "pledge":


### PR DESCRIPTION
### Proposed changes in this pull request

- add pov status to mintage api 
- relation module subscribe event bus
- add apis to get genesis blocks

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
