### PR TITLE
fix: generate settlement contract rewards block

### DIFF
--- a/vm/contract/settlement_test.go
+++ b/vm/contract/settlement_test.go
@@ -384,6 +384,14 @@ func TestCreate_And_Terminate_Contract(t *testing.T) {
 						if err := ctx.SaveStorage(); err != nil {
 							t.Fatal(err)
 						} else {
+							if r, err := terminateContract.GetTargetReceiver(ctx, sb); err != nil {
+								t.Fatal(err)
+							} else {
+								if r != a1 {
+									t.Fatalf("act: %s, exp: %s", r.String(), a1.String())
+								}
+							}
+
 							if c, err := cabi.GetSettlementContract(ctx, &address); err != nil {
 								t.Fatal(err)
 							} else {
@@ -890,6 +898,14 @@ func TestCreate_And_Sign_Contract(t *testing.T) {
 			}
 			if err := ctx.SaveStorage(); err != nil {
 				t.Fatal(err)
+			}
+
+			if r, err := createContract.GetTargetReceiver(ctx, sb); err != nil {
+				t.Fatal(err)
+			} else {
+				if r != a2 {
+					t.Fatalf("exp: %s, act: %s", a2.String(), r.String())
+				}
 			}
 		}
 


### PR DESCRIPTION
- merge all generate rewards block API into one
- implement `GetTargetReceiver`

Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Proposed changes in this pull request

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
