### PR TITLE
refactor: update summary report data structure

### DIFF
--- a/vm/contract/abi/abi_settlement_gen.go
+++ b/vm/contract/abi/abi_settlement_gen.go
@@ -599,75 +599,73 @@ func (z *CompareRecord) DecodeMsg(dc *msgp.Reader) (err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "PartyA":
-			if dc.IsNil() {
-				err = dc.ReadNil()
+			var zb0002 uint32
+			zb0002, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "PartyA")
+				return
+			}
+			for zb0002 > 0 {
+				zb0002--
+				field, err = dc.ReadMapKeyPtr()
 				if err != nil {
 					err = msgp.WrapError(err, "PartyA")
 					return
 				}
-				z.PartyA = nil
-			} else {
-				if z.PartyA == nil {
-					z.PartyA = new(SummaryRecord)
-				}
-				err = z.PartyA.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "PartyA")
-					return
+				switch msgp.UnsafeString(field) {
+				case "Orphan":
+					err = z.PartyA.Orphan.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyA", "Orphan")
+						return
+					}
+				case "Matching":
+					err = z.PartyA.Matching.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyA", "Matching")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "PartyA")
+						return
+					}
 				}
 			}
 		case "PartyB":
-			if dc.IsNil() {
-				err = dc.ReadNil()
+			var zb0003 uint32
+			zb0003, err = dc.ReadMapHeader()
+			if err != nil {
+				err = msgp.WrapError(err, "PartyB")
+				return
+			}
+			for zb0003 > 0 {
+				zb0003--
+				field, err = dc.ReadMapKeyPtr()
 				if err != nil {
 					err = msgp.WrapError(err, "PartyB")
 					return
 				}
-				z.PartyB = nil
-			} else {
-				if z.PartyB == nil {
-					z.PartyB = new(SummaryRecord)
-				}
-				err = z.PartyB.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "PartyB")
-					return
-				}
-			}
-		case "Orphan":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					err = msgp.WrapError(err, "Orphan")
-					return
-				}
-				z.Orphan = nil
-			} else {
-				if z.Orphan == nil {
-					z.Orphan = new(SummaryRecord)
-				}
-				err = z.Orphan.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "Orphan")
-					return
-				}
-			}
-		case "Matching":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					err = msgp.WrapError(err, "Matching")
-					return
-				}
-				z.Matching = nil
-			} else {
-				if z.Matching == nil {
-					z.Matching = new(SummaryRecord)
-				}
-				err = z.Matching.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "Matching")
-					return
+				switch msgp.UnsafeString(field) {
+				case "Orphan":
+					err = z.PartyB.Orphan.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyB", "Orphan")
+						return
+					}
+				case "Matching":
+					err = z.PartyB.Matching.DecodeMsg(dc)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyB", "Matching")
+						return
+					}
+				default:
+					err = dc.Skip()
+					if err != nil {
+						err = msgp.WrapError(err, "PartyB")
+						return
+					}
 				}
 			}
 		default:
@@ -683,74 +681,50 @@ func (z *CompareRecord) DecodeMsg(dc *msgp.Reader) (err error) {
 
 // EncodeMsg implements msgp.Encodable
 func (z *CompareRecord) EncodeMsg(en *msgp.Writer) (err error) {
-	// map header, size 4
+	// map header, size 2
 	// write "PartyA"
-	err = en.Append(0x84, 0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x41)
-	if err != nil {
-		return
-	}
-	if z.PartyA == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.PartyA.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "PartyA")
-			return
-		}
-	}
-	// write "PartyB"
-	err = en.Append(0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x42)
-	if err != nil {
-		return
-	}
-	if z.PartyB == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.PartyB.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "PartyB")
-			return
-		}
-	}
+	// map header, size 2
 	// write "Orphan"
-	err = en.Append(0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
+	err = en.Append(0x82, 0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x41, 0x82, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
 	if err != nil {
 		return
 	}
-	if z.Orphan == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.Orphan.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "Orphan")
-			return
-		}
+	err = z.PartyA.Orphan.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyA", "Orphan")
+		return
 	}
 	// write "Matching"
 	err = en.Append(0xa8, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x69, 0x6e, 0x67)
 	if err != nil {
 		return
 	}
-	if z.Matching == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.Matching.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "Matching")
-			return
-		}
+	err = z.PartyA.Matching.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyA", "Matching")
+		return
+	}
+	// write "PartyB"
+	// map header, size 2
+	// write "Orphan"
+	err = en.Append(0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x42, 0x82, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
+	if err != nil {
+		return
+	}
+	err = z.PartyB.Orphan.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyB", "Orphan")
+		return
+	}
+	// write "Matching"
+	err = en.Append(0xa8, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x69, 0x6e, 0x67)
+	if err != nil {
+		return
+	}
+	err = z.PartyB.Matching.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyB", "Matching")
+		return
 	}
 	return
 }
@@ -758,50 +732,38 @@ func (z *CompareRecord) EncodeMsg(en *msgp.Writer) (err error) {
 // MarshalMsg implements msgp.Marshaler
 func (z *CompareRecord) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.Require(b, z.Msgsize())
-	// map header, size 4
+	// map header, size 2
 	// string "PartyA"
-	o = append(o, 0x84, 0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x41)
-	if z.PartyA == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.PartyA.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "PartyA")
-			return
-		}
-	}
-	// string "PartyB"
-	o = append(o, 0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x42)
-	if z.PartyB == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.PartyB.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "PartyB")
-			return
-		}
-	}
+	// map header, size 2
 	// string "Orphan"
-	o = append(o, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
-	if z.Orphan == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.Orphan.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Orphan")
-			return
-		}
+	o = append(o, 0x82, 0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x41, 0x82, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
+	o, err = z.PartyA.Orphan.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyA", "Orphan")
+		return
 	}
 	// string "Matching"
 	o = append(o, 0xa8, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x69, 0x6e, 0x67)
-	if z.Matching == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.Matching.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Matching")
-			return
-		}
+	o, err = z.PartyA.Matching.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyA", "Matching")
+		return
+	}
+	// string "PartyB"
+	// map header, size 2
+	// string "Orphan"
+	o = append(o, 0xa6, 0x50, 0x61, 0x72, 0x74, 0x79, 0x42, 0x82, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
+	o, err = z.PartyB.Orphan.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyB", "Orphan")
+		return
+	}
+	// string "Matching"
+	o = append(o, 0xa8, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x69, 0x6e, 0x67)
+	o, err = z.PartyB.Matching.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "PartyB", "Matching")
+		return
 	}
 	return
 }
@@ -825,71 +787,73 @@ func (z *CompareRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		}
 		switch msgp.UnsafeString(field) {
 		case "PartyA":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.PartyA = nil
-			} else {
-				if z.PartyA == nil {
-					z.PartyA = new(SummaryRecord)
-				}
-				bts, err = z.PartyA.UnmarshalMsg(bts)
+			var zb0002 uint32
+			zb0002, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PartyA")
+				return
+			}
+			for zb0002 > 0 {
+				zb0002--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PartyA")
 					return
 				}
+				switch msgp.UnsafeString(field) {
+				case "Orphan":
+					bts, err = z.PartyA.Orphan.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyA", "Orphan")
+						return
+					}
+				case "Matching":
+					bts, err = z.PartyA.Matching.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyA", "Matching")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyA")
+						return
+					}
+				}
 			}
 		case "PartyB":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.PartyB = nil
-			} else {
-				if z.PartyB == nil {
-					z.PartyB = new(SummaryRecord)
-				}
-				bts, err = z.PartyB.UnmarshalMsg(bts)
+			var zb0003 uint32
+			zb0003, bts, err = msgp.ReadMapHeaderBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "PartyB")
+				return
+			}
+			for zb0003 > 0 {
+				zb0003--
+				field, bts, err = msgp.ReadMapKeyZC(bts)
 				if err != nil {
 					err = msgp.WrapError(err, "PartyB")
 					return
 				}
-			}
-		case "Orphan":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.Orphan = nil
-			} else {
-				if z.Orphan == nil {
-					z.Orphan = new(SummaryRecord)
-				}
-				bts, err = z.Orphan.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Orphan")
-					return
-				}
-			}
-		case "Matching":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.Matching = nil
-			} else {
-				if z.Matching == nil {
-					z.Matching = new(SummaryRecord)
-				}
-				bts, err = z.Matching.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Matching")
-					return
+				switch msgp.UnsafeString(field) {
+				case "Orphan":
+					bts, err = z.PartyB.Orphan.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyB", "Orphan")
+						return
+					}
+				case "Matching":
+					bts, err = z.PartyB.Matching.UnmarshalMsg(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyB", "Matching")
+						return
+					}
+				default:
+					bts, err = msgp.Skip(bts)
+					if err != nil {
+						err = msgp.WrapError(err, "PartyB")
+						return
+					}
 				}
 			}
 		default:
@@ -906,30 +870,7 @@ func (z *CompareRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
 
 // Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
 func (z *CompareRecord) Msgsize() (s int) {
-	s = 1 + 7
-	if z.PartyA == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.PartyA.Msgsize()
-	}
-	s += 7
-	if z.PartyB == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.PartyB.Msgsize()
-	}
-	s += 7
-	if z.Orphan == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.Orphan.Msgsize()
-	}
-	s += 9
-	if z.Matching == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.Matching.Msgsize()
-	}
+	s = 1 + 7 + 1 + 7 + z.PartyA.Orphan.Msgsize() + 9 + z.PartyA.Matching.Msgsize() + 7 + 1 + 7 + z.PartyB.Orphan.Msgsize() + 9 + z.PartyB.Matching.Msgsize()
 	return
 }
 
@@ -2836,6 +2777,142 @@ func (z *InvoiceRecord) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *MatchingRecord) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Orphan":
+			err = z.Orphan.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "Orphan")
+				return
+			}
+		case "Matching":
+			err = z.Matching.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "Matching")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z *MatchingRecord) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "Orphan"
+	err = en.Append(0x82, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
+	if err != nil {
+		return
+	}
+	err = z.Orphan.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "Orphan")
+		return
+	}
+	// write "Matching"
+	err = en.Append(0xa8, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x69, 0x6e, 0x67)
+	if err != nil {
+		return
+	}
+	err = z.Matching.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "Matching")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z *MatchingRecord) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "Orphan"
+	o = append(o, 0x82, 0xa6, 0x4f, 0x72, 0x70, 0x68, 0x61, 0x6e)
+	o, err = z.Orphan.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "Orphan")
+		return
+	}
+	// string "Matching"
+	o = append(o, 0xa8, 0x4d, 0x61, 0x74, 0x63, 0x68, 0x69, 0x6e, 0x67)
+	o, err = z.Matching.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "Matching")
+		return
+	}
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *MatchingRecord) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "Orphan":
+			bts, err = z.Orphan.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Orphan")
+				return
+			}
+		case "Matching":
+			bts, err = z.Matching.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Matching")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z *MatchingRecord) Msgsize() (s int) {
+	s = 1 + 7 + z.Orphan.Msgsize() + 9 + z.Matching.Msgsize()
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *SendingStatus) DecodeMsg(dc *msgp.Reader) (err error) {
 	{
 		var zb0001 int
@@ -3596,22 +3673,10 @@ func (z *SummaryResult) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.Records[za0001] = za0002
 			}
 		case "Total":
-			if dc.IsNil() {
-				err = dc.ReadNil()
-				if err != nil {
-					err = msgp.WrapError(err, "Total")
-					return
-				}
-				z.Total = nil
-			} else {
-				if z.Total == nil {
-					z.Total = new(CompareRecord)
-				}
-				err = z.Total.DecodeMsg(dc)
-				if err != nil {
-					err = msgp.WrapError(err, "Total")
-					return
-				}
+			err = z.Total.DecodeMsg(dc)
+			if err != nil {
+				err = msgp.WrapError(err, "Total")
+				return
 			}
 		default:
 			err = dc.Skip()
@@ -3678,17 +3743,10 @@ func (z *SummaryResult) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	if z.Total == nil {
-		err = en.WriteNil()
-		if err != nil {
-			return
-		}
-	} else {
-		err = z.Total.EncodeMsg(en)
-		if err != nil {
-			err = msgp.WrapError(err, "Total")
-			return
-		}
+	err = z.Total.EncodeMsg(en)
+	if err != nil {
+		err = msgp.WrapError(err, "Total")
+		return
 	}
 	return
 }
@@ -3725,14 +3783,10 @@ func (z *SummaryResult) MarshalMsg(b []byte) (o []byte, err error) {
 	}
 	// string "Total"
 	o = append(o, 0xa5, 0x54, 0x6f, 0x74, 0x61, 0x6c)
-	if z.Total == nil {
-		o = msgp.AppendNil(o)
-	} else {
-		o, err = z.Total.MarshalMsg(o)
-		if err != nil {
-			err = msgp.WrapError(err, "Total")
-			return
-		}
+	o, err = z.Total.MarshalMsg(o)
+	if err != nil {
+		err = msgp.WrapError(err, "Total")
+		return
 	}
 	return
 }
@@ -3814,21 +3868,10 @@ func (z *SummaryResult) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.Records[za0001] = za0002
 			}
 		case "Total":
-			if msgp.IsNil(bts) {
-				bts, err = msgp.ReadNilBytes(bts)
-				if err != nil {
-					return
-				}
-				z.Total = nil
-			} else {
-				if z.Total == nil {
-					z.Total = new(CompareRecord)
-				}
-				bts, err = z.Total.UnmarshalMsg(bts)
-				if err != nil {
-					err = msgp.WrapError(err, "Total")
-					return
-				}
+			bts, err = z.Total.UnmarshalMsg(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "Total")
+				return
 			}
 		default:
 			bts, err = msgp.Skip(bts)
@@ -3862,12 +3905,7 @@ func (z *SummaryResult) Msgsize() (s int) {
 			}
 		}
 	}
-	s += 6
-	if z.Total == nil {
-		s += msgp.NilSize
-	} else {
-		s += z.Total.Msgsize()
-	}
+	s += 6 + z.Total.Msgsize()
 	return
 }
 

--- a/vm/contract/abi/abi_settlement_gen_test.go
+++ b/vm/contract/abi/abi_settlement_gen_test.go
@@ -1026,6 +1026,119 @@ func BenchmarkDecodeInvoiceRecord(b *testing.B) {
 	}
 }
 
+func TestMarshalUnmarshalMatchingRecord(t *testing.T) {
+	v := MatchingRecord{}
+	bts, err := v.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	left, err := v.UnmarshalMsg(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after UnmarshalMsg(): %q", len(left), left)
+	}
+
+	left, err = msgp.Skip(bts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) > 0 {
+		t.Errorf("%d bytes left over after Skip(): %q", len(left), left)
+	}
+}
+
+func BenchmarkMarshalMsgMatchingRecord(b *testing.B) {
+	v := MatchingRecord{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.MarshalMsg(nil)
+	}
+}
+
+func BenchmarkAppendMsgMatchingRecord(b *testing.B) {
+	v := MatchingRecord{}
+	bts := make([]byte, 0, v.Msgsize())
+	bts, _ = v.MarshalMsg(bts[0:0])
+	b.SetBytes(int64(len(bts)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bts, _ = v.MarshalMsg(bts[0:0])
+	}
+}
+
+func BenchmarkUnmarshalMatchingRecord(b *testing.B) {
+	v := MatchingRecord{}
+	bts, _ := v.MarshalMsg(nil)
+	b.ReportAllocs()
+	b.SetBytes(int64(len(bts)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := v.UnmarshalMsg(bts)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestEncodeDecodeMatchingRecord(t *testing.T) {
+	v := MatchingRecord{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+
+	m := v.Msgsize()
+	if buf.Len() > m {
+		t.Logf("WARNING: Msgsize() for %v is inaccurate", v)
+	}
+
+	vn := MatchingRecord{}
+	err := msgp.Decode(&buf, &vn)
+	if err != nil {
+		t.Error(err)
+	}
+
+	buf.Reset()
+	msgp.Encode(&buf, &v)
+	err = msgp.NewReader(&buf).Skip()
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func BenchmarkEncodeMatchingRecord(b *testing.B) {
+	v := MatchingRecord{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	en := msgp.NewWriter(msgp.Nowhere)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		v.EncodeMsg(en)
+	}
+	en.Flush()
+}
+
+func BenchmarkDecodeMatchingRecord(b *testing.B) {
+	v := MatchingRecord{}
+	var buf bytes.Buffer
+	msgp.Encode(&buf, &v)
+	b.SetBytes(int64(buf.Len()))
+	rd := msgp.NewEndlessReader(buf.Bytes(), b)
+	dc := msgp.NewReader(rd)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := v.DecodeMsg(dc)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 func TestMarshalUnmarshalSettlementCDR(t *testing.T) {
 	v := SettlementCDR{}
 	bts, err := v.MarshalMsg(nil)

--- a/vm/contract/abi/abi_settlement_test.go
+++ b/vm/contract/abi/abi_settlement_test.go
@@ -8119,15 +8119,10 @@ func TestNewSummaryResult(t *testing.T) {
 	r := NewSummaryResult()
 
 	for i := 0; i < 20; i++ {
-		r.UpdatePartyState("WeChat", true, i%3 == 0)
-		r.UpdatePartyState("WeChat", false, i%2 == 0)
-		r.UpdatePartyState("Slack", true, i%2 == 0)
-		r.UpdatePartyState("Slack", false, i%3 == 0)
-	}
-
-	for i := 0; i < 5; i++ {
-		r.UpdateGlobalState("WeChat", true, i%2 == 0)
-		r.UpdateGlobalState("Slack", false, i%2 == 0)
+		r.UpdateState("WeChat", true, i%3 == 0, i%2 == 0)
+		r.UpdateState("WeChat", false, i%2 == 0, i%3 == 0)
+		r.UpdateState("Slack", true, i%2 == 0, i%3 == 0)
+		r.UpdateState("Slack", false, i%3 == 0, i%2 == 0)
 	}
 
 	r.DoCalculate()
@@ -8146,11 +8141,12 @@ func TestCDRStatus_State(t *testing.T) {
 		addr *types.Address
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
-		want1  bool
+		name    string
+		fields  fields
+		args    args
+		want    string
+		want1   bool
+		wantErr bool
 	}{
 		{
 			name: "ok",
@@ -8161,8 +8157,9 @@ func TestCDRStatus_State(t *testing.T) {
 			args: args{
 				addr: &addr1,
 			},
-			want:  "PCCWG",
-			want1: true,
+			want:    "PCCWG",
+			want1:   true,
+			wantErr: false,
 		}, {
 			name: "f1",
 			fields: fields{
@@ -8172,8 +8169,9 @@ func TestCDRStatus_State(t *testing.T) {
 			args: args{
 				addr: &addr1,
 			},
-			want:  "",
-			want1: false,
+			want:    "",
+			want1:   false,
+			wantErr: true,
 		}, {
 			name: "f2",
 			fields: fields{
@@ -8183,8 +8181,9 @@ func TestCDRStatus_State(t *testing.T) {
 			args: args{
 				addr: &addr2,
 			},
-			want:  "",
-			want1: false,
+			want:    "",
+			want1:   false,
+			wantErr: true,
 		}, {
 			name: "f3",
 			fields: fields{
@@ -8194,8 +8193,9 @@ func TestCDRStatus_State(t *testing.T) {
 			args: args{
 				addr: &addr1,
 			},
-			want:  "PCCWG",
-			want1: false,
+			want:    "PCCWG",
+			want1:   false,
+			wantErr: false,
 		}, {
 			name: "f4",
 			fields: fields{
@@ -8205,8 +8205,9 @@ func TestCDRStatus_State(t *testing.T) {
 			args: args{
 				addr: &addr1,
 			},
-			want:  "",
-			want1: false,
+			want:    "",
+			want1:   false,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -8215,7 +8216,11 @@ func TestCDRStatus_State(t *testing.T) {
 				Params: tt.fields.Params,
 				Status: tt.fields.Status,
 			}
-			got, got1 := z.State(tt.args.addr)
+			got, got1, err := z.State(tt.args.addr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("State() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 			if got != tt.want {
 				t.Errorf("State() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Signed-off-by: Goren G <yong.gu@qlink.mobi>

### Proposed changes in this pull request

new output result

```json
{
    "jsonrpc": "2.0",
    "id": 3,
    "result": {
        "contract": {
            "partyA": {
                "address": "qlc_3giz1uwgsmq46xzspo9mbutade6foqh5fuja4m9rwfiuyzp4x8zu5hkorq4z",
                "name": "PCCWG"
            },
            "partyB": {
                "address": "qlc_3exbms47d63ywggnhb9iko9twphsnsx563qf6faufp33167o5dqfoawa8gtj",
                "name": "HKTCSL"
            },
            "previous": "a77862e3de249df4c95f17df399a902f23e377ae0d05cf2e4becc83247b9591d",
            "services": [
                {
                    "serviceId": "ab3d2c3d0be06e7f6bab089e198c7816a1ae88fb241ca94d7a8df09ad95abfd0",
                    "mcc": 460,
                    "mnc": 46,
                    "totalAmount": 10000,
                    "unitPrice": 0.0426,
                    "currency": "USD"
                },
                {
                    "serviceId": "b5983e8ac72f04548fa99789b08014904f71e1f5b48c5d47fff8507efd51d85a",
                    "mcc": 460,
                    "mnc": 2,
                    "totalAmount": 300000,
                    "unitPrice": 0.023,
                    "currency": "USD"
                }
            ],
            "signDate": 1582799181,
            "startDate": 1582799263,
            "endDate": 1613356422,
            "preStops": [
                "A2P_PCCWG"
            ],
            "nextStops": [
                "CSL Hong Kong @ 3397"
            ],
            "confirmDate": 1582799183,
            "status": "Activated"
        },
        "records": {
            "WeChat": {
                "partyA": {
                    "orphan": {
                        "total": 32,
                        "success": 27,
                        "fail": 5,
                        "result": 0.84375
                    },
                    "matching": {
                        "total": 177,
                        "success": 177,
                        "fail": 0,
                        "result": 1
                    }
                },
                "partyB": {
                    "orphan": {
                        "total": 89,
                        "success": 67,
                        "fail": 22,
                        "result": 0.7528089887640449
                    },
                    "matching": {
                        "total": 177,
                        "success": 177,
                        "fail": 0,
                        "result": 1
                    }
                }
            }
        },
        "total": {
            "partyA": {
                "orphan": {
                    "total": 32,
                    "success": 27,
                    "fail": 5,
                    "result": 0.84375
                },
                "matching": {
                    "total": 177,
                    "success": 177,
                    "fail": 0,
                    "result": 1
                }
            },
            "partyB": {
                "orphan": {
                    "total": 89,
                    "success": 67,
                    "fail": 22,
                    "result": 0.7528089887640449
                },
                "matching": {
                    "total": 177,
                    "success": 177,
                    "fail": 0,
                    "result": 1
                }
            }
        }
    }
}
```

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [x] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
