### PR TITLE
fix: nodes count exclude the removed ones

### DIFF
--- a/consensus/dpos/dpos_impl_test.go
+++ b/consensus/dpos/dpos_impl_test.go
@@ -214,6 +214,15 @@ func TestOnRollback(t *testing.T) {
 	benefit.Total = dps.minVoteWeight
 	dps.ledger.AddRepresentation(account.Address(), benefit, dps.ledger.Cache().GetCache())
 	dps.ledger.AddStateBlock(blk)
+
+	header := mock.StateBlockWithoutWork()
+	header.Address = mock.Address()
+	dps.ledger.AddStateBlock(header)
+	am := mock.AccountMeta(account.Address())
+	am.Tokens[0].Type = config.ChainToken()
+	am.Tokens[0].Header = header.GetHash()
+	dps.ledger.AddAccountMeta(am, dps.ledger.Cache().GetCache())
+
 	dps.onRollback(blk.GetHash())
 }
 

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -125,10 +125,7 @@ func TestOnline(t *testing.T) {
 	n1.TestWithTimeout(30*time.Second, func() bool {
 		repOnline := make(map[uint64]*RepOnlinePeriod)
 		n1.cons.RPC(common.RpcDPoSOnlineInfo, nil, repOnline)
-		if repOnline[0].Stat[TestAccount.Address()].HeartCount != 59 {
-			return false
-		}
-		return true
+		return repOnline[0].Stat[TestAccount.Address()].HeartCount == 59
 	})
 
 	n1.TestWithTimeout(30*time.Second, func() bool {

--- a/consensus/dpos/dpos_integration_test.go
+++ b/consensus/dpos/dpos_integration_test.go
@@ -123,13 +123,12 @@ func TestOnline(t *testing.T) {
 	}
 
 	n1.TestWithTimeout(30*time.Second, func() bool {
-		repOnline := make(map[uint64]*RepOnlinePeriod, 0)
+		repOnline := make(map[uint64]*RepOnlinePeriod)
 		n1.cons.RPC(common.RpcDPoSOnlineInfo, nil, repOnline)
 		if repOnline[0].Stat[TestAccount.Address()].HeartCount != 59 {
 			return false
-		} else {
-			return true
 		}
+		return true
 	})
 
 	n1.TestWithTimeout(30*time.Second, func() bool {

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -560,9 +560,8 @@ func (n *Node) TestWithTimeout(to time.Duration, fn func() bool) {
 		default:
 			if fn() {
 				return
-			} else {
-				time.Sleep(time.Second)
 			}
+			time.Sleep(time.Second)
 		}
 	}
 }

--- a/consensus/dpos/dpos_test.go
+++ b/consensus/dpos/dpos_test.go
@@ -549,3 +549,20 @@ func (n *Node) VoteBlock(acc *types.Account, blk *types.StateBlock) {
 	}
 	n.dps.processors[index].acks <- vi
 }
+
+func (n *Node) TestWithTimeout(to time.Duration, fn func() bool) {
+	ti := time.NewTimer(to)
+	defer ti.Stop()
+	for {
+		select {
+		case <-ti.C:
+			n.t.Fatal()
+		default:
+			if fn() {
+				return
+			} else {
+				time.Sleep(time.Second)
+			}
+		}
+	}
+}

--- a/consensus/dpos/online_test.go
+++ b/consensus/dpos/online_test.go
@@ -46,6 +46,8 @@ func TestGetOnlineInfo(t *testing.T) {
 	} else {
 		t.Fatal()
 	}
+
+	t.Log(repg.String())
 }
 
 func TestVoteHistoryUpdate(t *testing.T) {

--- a/consensus/dpos/processor_test.go
+++ b/consensus/dpos/processor_test.go
@@ -210,3 +210,31 @@ func TestProcessor_dequeueGapPublish(t *testing.T) {
 		return nil
 	})
 }
+
+func TestProcessor_processFrontier(t *testing.T) {
+	dps := getTestDpos()
+	processor := dps.processors[0]
+	blk1 := mock.StateBlockWithoutWork()
+	blk2 := mock.StateBlockWithoutWork()
+
+	blk1.Previous = mock.Hash()
+	blk2.Previous = blk1.Previous
+	dps.acTrx.addToRoots(blk1)
+	processor.processFrontier(blk2)
+
+	if _, ok := dps.hash2el.Load(blk2.GetHash()); !ok {
+		t.Fatal()
+	}
+}
+
+func TestProcessor_enqueueUncheckedSync(t *testing.T) {
+	dps := getTestDpos()
+	processor := dps.processors[0]
+	blk := mock.StateBlockWithoutWork()
+	blk.Previous = mock.Hash()
+
+	processor.enqueueUncheckedSync(blk)
+	if has, _ := dps.ledger.HasUncheckedSyncBlock(blk.Previous); !has {
+		t.Fatal()
+	}
+}

--- a/vm/contract/abi/abi_permission.go
+++ b/vm/contract/abi/abi_permission.go
@@ -140,8 +140,11 @@ func GetAllPermissionNodes(ctx *vmstore.VMContext) ([]*PermNode, error) {
 			return err
 		}
 
-		pn.Index = index
-		nodes = append(nodes, pn)
+		if pn.Valid {
+			pn.Index = index
+			nodes = append(nodes, pn)
+		}
+
 		return nil
 	})
 


### PR DESCRIPTION
Signed-off-by: lichao <chao.li@qlink.mobi>

### Proposed changes in this pull request
nodes count exclude the removed nodes

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
