### PR TITLE
feat: add an rpc interface to query the peerid of node

### DIFF
--- a/rpc/api/net.go
+++ b/rpc/api/net.go
@@ -147,3 +147,8 @@ func (q *NetApi) Syncing() bool {
 	}
 	return false
 }
+
+func (q *NetApi) GetPeerId() string {
+	cfg, _ := q.cc.Config()
+	return cfg.P2P.ID.PeerID
+}

--- a/rpc/api/net_test.go
+++ b/rpc/api/net_test.go
@@ -251,3 +251,13 @@ func TestNetApi_OnlineRepsInfo(t *testing.T) {
 		t.Fatal("online info error")
 	}
 }
+
+func TestNetApi_GetPeerId(t *testing.T) {
+	teardownTestCase, _, netApi := setupTestCaseNet(t)
+	defer teardownTestCase(t)
+	cfg, _ := netApi.cc.Config()
+	p := netApi.GetPeerId()
+	if cfg.P2P.ID.PeerID != p {
+		t.Fatal("get peer id error")
+	}
+}


### PR DESCRIPTION
Signed-off-by: wenchao <659672152@qq.com>

### Proposed changes in this pull request
- fix #1086 

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
