### PR TITLE
feat: add permission service to add preconfigured nodes automatically

### DIFF
--- a/chain/context/chain_context.go
+++ b/chain/context/chain_context.go
@@ -45,6 +45,7 @@ const (
 	LogService          = "logService"
 	ResendBlockService  = "resendBlockService"
 	PrivacyService      = "privacyService"
+	PermissionService   = "permissionService"
 )
 
 type serviceManager interface {

--- a/chain/context/chain_context.go
+++ b/chain/context/chain_context.go
@@ -360,7 +360,7 @@ func (cc *ChainContext) ConfigManager(opts ...Option) (*config.CfgManager, error
 	if cc.cm == nil {
 		cc.cm = config.NewCfgManagerWithFile(cc.cfgFile)
 		_, err := cc.cm.Load(config.NewMigrationV1ToV2(), config.NewMigrationV2ToV3(), config.NewMigrationV3ToV4(),
-			config.NewMigrationV4ToV5(), config.NewMigrationV5ToV6())
+			config.NewMigrationV4ToV5(), config.NewMigrationV5ToV6(), config.NewMigrationV6ToV7())
 		if err != nil {
 			return nil, err
 		}

--- a/chain/helper.go
+++ b/chain/helper.go
@@ -79,5 +79,10 @@ func RegisterServices(cc *context.ChainContext) error {
 		_ = cc.Register(context.PrivacyService, privacyService)
 	}
 
+	if cfg.WhiteList.Enable {
+		permService := NewPermissionService(cfgFile)
+		_ = cc.Register(context.PermissionService, permService)
+	}
+
 	return nil
 }

--- a/chain/permission_service.go
+++ b/chain/permission_service.go
@@ -199,7 +199,7 @@ func (ps *PermissionService) addPermissionNode() {
 
 			for _, param := range ps.nodes {
 				blk := new(types.StateBlock)
-				err := ps.client.Call(&blk, "permission_getNodeUpdateBlock", &param)
+				err := ps.client.Call(&blk, "permission_getNodeUpdateBlock", param)
 				if err != nil {
 					ps.logger.Error(err)
 					continue

--- a/chain/permission_service.go
+++ b/chain/permission_service.go
@@ -1,0 +1,224 @@
+package chain
+
+import (
+	"time"
+
+	"github.com/AsynkronIT/protoactor-go/actor"
+	rpc "github.com/qlcchain/jsonrpc2"
+	"go.uber.org/zap"
+
+	"github.com/qlcchain/go-qlc/chain/context"
+	"github.com/qlcchain/go-qlc/common"
+	"github.com/qlcchain/go-qlc/common/event"
+	"github.com/qlcchain/go-qlc/common/topic"
+	"github.com/qlcchain/go-qlc/common/types"
+	"github.com/qlcchain/go-qlc/config"
+	"github.com/qlcchain/go-qlc/ledger"
+	"github.com/qlcchain/go-qlc/log"
+	"github.com/qlcchain/go-qlc/rpc/api"
+	"github.com/qlcchain/go-qlc/vm/contract/abi"
+	"github.com/qlcchain/go-qlc/vm/vmstore"
+)
+
+type PermissionService struct {
+	common.ServiceLifecycle
+	logger     *zap.SugaredLogger
+	cfgFile    string
+	cfg        *config.Config
+	cc         *context.ChainContext
+	subscriber *event.ActorSubscriber
+	work       chan struct{}
+	exit       chan struct{}
+	account    *types.Account
+	client     *rpc.Client
+	vmCtx      *vmstore.VMContext
+	checkTime  uint8
+	nodes      []*api.NodeParam
+	blkHash    []types.Hash
+}
+
+func NewPermissionService(cfgFile string) *PermissionService {
+	cm := config.NewCfgManagerWithFile(cfgFile)
+	cfg, _ := cm.Config()
+	l := ledger.NewLedger(cfgFile)
+
+	ps := &PermissionService{
+		cfgFile: cfgFile,
+		logger:  log.NewLogger("permission service"),
+		cfg:     cfg,
+		cc:      context.NewChainContext(cfgFile),
+		work:    make(chan struct{}, 1),
+		exit:    make(chan struct{}, 1),
+		vmCtx:   vmstore.NewVMContext(l),
+		nodes:   make([]*api.NodeParam, 0),
+	}
+
+	return ps
+}
+
+func (ps *PermissionService) Init() error {
+	ps.PreInit()
+
+	admin, err := abi.PermissionGetAdmin(ps.vmCtx)
+	if err != nil {
+		return err
+	}
+
+	for _, acc := range ps.cc.Accounts() {
+		for _, adm := range admin {
+			if acc.Address() == adm.Account {
+				ps.account = acc
+				break
+			}
+		}
+	}
+
+	if ps.account == nil {
+		return nil
+	}
+
+	// check if the nodes already exist in ledger
+	for _, n := range ps.cfg.WhiteList.WhiteListInfos {
+		ni, _ := abi.PermissionGetNode(ps.vmCtx, n.PeerId)
+		if ni == nil {
+			node := &api.NodeParam{
+				Admin:   ps.account.Address(),
+				NodeId:  n.PeerId,
+				NodeUrl: n.Addr,
+				Comment: n.Comment,
+			}
+			ps.nodes = append(ps.nodes, node)
+		}
+	}
+
+	ps.subscriber = event.NewActorSubscriber(event.Spawn(func(c actor.Context) {
+		switch msg := c.Message().(type) {
+		case topic.SyncState:
+			ps.onPovSyncState(msg)
+		}
+	}), ps.cc.EventBus())
+
+	if err := ps.subscriber.Subscribe(topic.EventPovSyncState); err != nil {
+		return err
+	}
+
+	ps.PostInit()
+	return nil
+}
+
+func (ps *PermissionService) Start() error {
+	ps.PreStart()
+
+	if len(ps.nodes) > 0 {
+		rs, err := ps.cc.Service(context.RPCService)
+		if err != nil {
+			ps.logger.Error(err)
+			return err
+		}
+
+		ps.client, err = rs.(*RPCService).RPC().Attach()
+		if err != nil {
+			ps.logger.Error(err)
+			return err
+		}
+
+		go ps.addPermissionNode()
+	}
+
+	ps.PostStart()
+	return nil
+}
+
+func (ps *PermissionService) Stop() error {
+	ps.PreStop()
+
+	if ps.subscriber != nil {
+		if err := ps.subscriber.UnsubscribeAll(); err != nil {
+			return err
+		}
+	}
+
+	ps.exit <- struct{}{}
+
+	ps.PostStop()
+	return nil
+}
+
+func (ps *PermissionService) Status() int32 {
+	return ps.State()
+}
+
+func (ps *PermissionService) onPovSyncState(state topic.SyncState) {
+	if state == topic.SyncDone {
+		ps.work <- struct{}{}
+	}
+}
+
+func (ps *PermissionService) addPermissionNode() {
+	checkInterval := time.NewTicker(5 * time.Second)
+	syncDone := false
+
+	for {
+		select {
+		case <-ps.exit:
+			ps.logger.Info("permission service exit")
+			return
+		case <-checkInterval.C:
+			// if can't get the node after 10 minutes, do it again
+			if !syncDone {
+				continue
+			}
+
+			ps.checkTime++
+
+			nodes := make([]*api.NodeParam, 0)
+			for i, h := range ps.blkHash {
+				if has, _ := ps.vmCtx.Ledger.HasStateBlockConfirmed(h); !has {
+					nodes = append(nodes, ps.nodes[i])
+				}
+
+				if len(nodes) > 0 {
+					if ps.checkTime >= 120 {
+						ps.nodes = nodes
+						ps.work <- struct{}{}
+						ps.checkTime = 0
+					}
+				} else {
+					ps.logger.Info("added all nodes, permission service exit")
+					return
+				}
+			}
+		case <-ps.work:
+			syncDone = true
+
+			if !ps.cc.IsPoVDone() {
+				ps.work <- struct{}{}
+				time.Sleep(time.Second)
+				continue
+			}
+
+			for _, param := range ps.nodes {
+				blk := new(types.StateBlock)
+				err := ps.client.Call(&blk, "permission_getNodeUpdateBlock", &param)
+				if err != nil {
+					ps.logger.Error(err)
+					continue
+				}
+
+				var w types.Work
+				worker, _ := types.NewWorker(w, blk.Root())
+				blk.Work = worker.NewWork()
+
+				hash := blk.GetHash()
+				blk.Signature = ps.account.Sign(hash)
+				ps.blkHash = append(ps.blkHash, hash)
+
+				var h types.Hash
+				err = ps.client.Call(&h, "ledger_process", &blk)
+				if err != nil {
+					ps.logger.Error(err)
+				}
+			}
+		}
+	}
+}

--- a/chain/permission_service_test.go
+++ b/chain/permission_service_test.go
@@ -1,0 +1,159 @@
+package chain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qlcchain/go-qlc/chain/context"
+	"github.com/qlcchain/go-qlc/common/statedb"
+	"github.com/qlcchain/go-qlc/common/topic"
+	"github.com/qlcchain/go-qlc/common/types"
+	"github.com/qlcchain/go-qlc/common/vmcontract/contractaddress"
+	"github.com/qlcchain/go-qlc/config"
+	"github.com/qlcchain/go-qlc/ledger"
+	"github.com/qlcchain/go-qlc/mock"
+	"github.com/qlcchain/go-qlc/vm/contract/abi"
+)
+
+func addTestAdmin(t *testing.T, l *ledger.Ledger, admin *abi.AdminAccount, povHeight uint64) {
+	povBlk, povTd := mock.GeneratePovBlockByFakePow(nil, 0)
+	povBlk.Header.BasHdr.Height = povHeight
+
+	gsdb := statedb.NewPovGlobalStateDB(l.DBStore(), types.ZeroHash)
+	csdb, err := gsdb.LookupContractStateDB(contractaddress.PermissionAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	trieKey := statedb.PovCreateContractLocalStateKey(abi.PermissionDataAdmin, admin.Account.Bytes())
+
+	data, err := admin.MarshalMsg(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = csdb.SetValue(trieKey, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = gsdb.CommitToTrie()
+	if err != nil {
+		t.Fatal(err)
+	}
+	txn := l.DBStore().Batch(true)
+	err = gsdb.CommitToDB(txn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = l.DBStore().PutBatch(txn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	povBlk.Header.CbTx.StateHash = gsdb.GetCurHash()
+	mock.UpdatePovHash(povBlk)
+
+	err = l.AddPovBlock(povBlk, povTd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = l.AddPovBestHash(povBlk.GetHeight(), povBlk.GetHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = l.SetPovLatestHeight(povBlk.GetHeight())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPermissionService(t *testing.T) {
+	dir := filepath.Join(config.QlcTestDataDir(), uuid.New().String())
+	cm := config.NewCfgManager(dir)
+	_, err := cm.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	ps := NewPermissionService(cm.ConfigFile)
+	cc := context.NewChainContext(cm.ConfigFile)
+	l := ledger.NewLedger(cm.ConfigFile)
+
+	rs, err := NewRPCService(cm.ConfigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cc.Register(context.RPCService, rs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = ps.Init()
+	if err == nil {
+		t.Fatal()
+	}
+
+	adminAccount := mock.Account()
+	admin := new(abi.AdminAccount)
+	admin.Account = adminAccount.Address()
+	admin.Comment = "t1"
+	admin.Valid = true
+	addTestAdmin(t, l, admin, 1)
+
+	err = ps.Init()
+	if err != nil {
+		t.Fatal()
+	}
+
+	am := mock.AccountMeta(adminAccount.Address())
+	am.Tokens[0].Type = config.ChainToken()
+	ps.vmCtx.Ledger.AddAccountMeta(am, ps.vmCtx.Ledger.Cache().GetCache())
+
+	cc.SetAccounts([]*types.Account{adminAccount})
+	wli := &config.WhiteListInfo{
+		PeerId:  "xxxxxxx",
+		Addr:    "127.0.0.1:9734",
+		Comment: "tn1",
+	}
+	ps.cfg.WhiteList.WhiteListInfos = append(ps.cfg.WhiteList.WhiteListInfos, wli)
+	err = ps.Init()
+	if err != nil {
+		t.Fatal()
+	}
+
+	err = ps.cc.Init(func() error {
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ps.cc.Start()
+
+	err = ps.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ps.Status()
+
+	ps.cc.EventBus().Publish(topic.EventPovSyncState, topic.SyncDone)
+	time.Sleep(10 * time.Second)
+
+	err = ps.Stop()
+	if err != nil {
+		t.Fatal()
+	}
+	time.Sleep(3 * time.Second)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -9,14 +9,14 @@ import (
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 )
 
-type Config ConfigV6
+type Config ConfigV7
 
 func DefaultConfig(dir string) (*Config, error) {
-	v6, err := DefaultConfigV6(dir)
+	v7, err := DefaultConfigV7(dir)
 	if err != nil {
 		return &Config{}, err
 	}
-	cfg := Config(*v6)
+	cfg := Config(*v7)
 
 	return &cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/qlcchain/go-qlc/common/util"
 )
 
-func TestConfig_LogDir(t *testing.T) {
-	cfg, err := DefaultConfigV1(DefaultDataDir())
+func TestConfig_Dir(t *testing.T) {
+	cfg, err := DefaultConfigV7(DefaultDataDir())
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Log(util.ToIndentString(cfg))
-
 	t.Log(cfg.DataDir)
-	//t.Log(cfg.LogDir())
-	//t.Log(cfg.LedgerDir())
-	//t.Log(cfg.WalletDir())
+	c := Config(*cfg)
+	t.Log(c.LogDir())
+	t.Log(c.LedgerDir())
+	t.Log(c.WalletDir())
 	t.Log(QlcTestDataDir())
 }

--- a/config/config_v2.go
+++ b/config/config_v2.go
@@ -25,8 +25,7 @@ type P2PConfigV2 struct {
 	BootNodeHttpServer string   `json:"bootNodeHttpServer"`
 	Listen             string   `json:"listen"`
 	// if you are bootNode,should fill in the listening ip
-	ListeningIp   string `json:"listeningIp"`
-	WhiteListMode bool   `json:"whiteListMode"`
+	ListeningIp string `json:"listeningIp"`
 	//Time in seconds between sync block interval
 	SyncInterval int                `json:"syncInterval"`
 	Discovery    *DiscoveryConfigV2 `json:"discovery"`

--- a/config/config_v2_default.go
+++ b/config/config_v2_default.go
@@ -41,7 +41,6 @@ func DefaultConfigV2(dir string) (*ConfigV2, error) {
 			BootNodeHttpServer: bootNodeHttpServer,
 			Listen:             "/ip4/0.0.0.0/tcp/9734",
 			ListeningIp:        "127.0.0.1",
-			WhiteListMode:      false,
 			SyncInterval:       120,
 			Discovery: &DiscoveryConfigV2{
 				DiscoveryInterval: 60,

--- a/config/config_v2_testnet.go
+++ b/config/config_v2_testnet.go
@@ -41,7 +41,6 @@ func DefaultConfigV2(dir string) (*ConfigV2, error) {
 			BootNodeHttpServer: bootNodeHttpServer,
 			Listen:             "/ip4/0.0.0.0/tcp/19734",
 			ListeningIp:        "127.0.0.1",
-			WhiteListMode:      false,
 			SyncInterval:       120,
 			Discovery: &DiscoveryConfigV2{
 				DiscoveryInterval: 60,

--- a/config/config_v7.go
+++ b/config/config_v7.go
@@ -1,0 +1,31 @@
+package config
+
+type ConfigV7 struct {
+	ConfigV6  `mapstructure:",squash"`
+	WhiteList *WhiteList `json:"whiteList"`
+}
+
+type WhiteList struct {
+	Enable         bool             `json:"enable"`
+	WhiteListInfos []*WhiteListInfo `json:"whiteListInfo"`
+}
+
+type WhiteListInfo struct {
+	PeerId string `json:"peerId"`
+	Addr   string `json:"addr"` //(for example, "192.0.2.1:25", "[2001:db8::1]:80")
+}
+
+func DefaultConfigV7(dir string) (*ConfigV7, error) {
+	var cfg ConfigV7
+	cfg6, _ := DefaultConfigV6(dir)
+	cfg.ConfigV6 = *cfg6
+	cfg.WhiteList = defaultWhiteList()
+	return &cfg, nil
+}
+
+func defaultWhiteList() *WhiteList {
+	return &WhiteList{
+		Enable:         false,
+		WhiteListInfos: []*WhiteListInfo{},
+	}
+}

--- a/config/config_v7.go
+++ b/config/config_v7.go
@@ -11,8 +11,9 @@ type WhiteList struct {
 }
 
 type WhiteListInfo struct {
-	PeerId string `json:"peerId"`
-	Addr   string `json:"addr"` //(for example, "192.0.2.1:25", "[2001:db8::1]:80")
+	PeerId  string `json:"peerId"`
+	Addr    string `json:"addr"` //(for example, "192.0.2.1:25", "[2001:db8::1]:80")
+	Comment string `json:"comment"`
 }
 
 func DefaultConfigV7(dir string) (*ConfigV7, error) {

--- a/config/defaults_net.go
+++ b/config/defaults_net.go
@@ -11,7 +11,7 @@ package config
 
 const (
 	QlcConfigFile      = "qlc.json"
-	configVersion      = 6
+	configVersion      = 7
 	cfgDir             = "GQlcchain"
 	nixCfgDir          = ".gqlcchain"
 	ipcName            = "gqlc.ipc"

--- a/config/defaults_testnet.go
+++ b/config/defaults_testnet.go
@@ -11,7 +11,7 @@ package config
 
 const (
 	QlcConfigFile      = "qlc.json"
-	configVersion      = 6
+	configVersion      = 7
 	cfgDir             = "GQlcchain_test"
 	nixCfgDir          = ".gqlcchain_test"
 	ipcName            = "gqlc-test.ipc"

--- a/config/genesis_test.go
+++ b/config/genesis_test.go
@@ -88,4 +88,32 @@ func TestGenesisInfo(t *testing.T) {
 	if !IsGenesisBlock(&gasMintageBlock) {
 		t.Fatal("this block should be genesis block: ", h4.String())
 	}
+	gs := GenesisInfos()
+	if len(gs) != 2 {
+		t.Fatal("get genesis infos error")
+	}
+	ck := ChainToken()
+	if ck != genesisBlock.Token {
+		t.Fatal("get chain token error")
+	}
+	gk := GasToken()
+	if gk != gasBlock.Token {
+		t.Fatal("get gas token error")
+	}
+	mh := GenesisMintageHash()
+	if mh != genesisMintageBlock.GetHash() {
+		t.Fatal("get genesis mintage block hash error")
+	}
+	gh := GenesisBlockHash()
+	if gh != genesisBlock.GetHash() {
+		t.Fatal("get genesis block hash error")
+	}
+	gasHash := GasBlockHash()
+	if gasHash != gasBlock.GetHash() {
+		t.Fatal("get gas block hash error")
+	}
+	ab := AllGenesisBlocks()
+	if len(ab) != 4 {
+		t.Fatal("get all block error")
+	}
 }

--- a/config/genesis_testnet_test.go
+++ b/config/genesis_testnet_test.go
@@ -88,4 +88,32 @@ func TestGenesisInfo(t *testing.T) {
 	if !IsGenesisBlock(&gasMintageBlock) {
 		t.Fatal("this block should be genesis block: ", h4.String())
 	}
+	gs := GenesisInfos()
+	if len(gs) != 2 {
+		t.Fatal("get genesis infos error")
+	}
+	ck := ChainToken()
+	if ck != genesisBlock.Token {
+		t.Fatal("get chain token error")
+	}
+	gk := GasToken()
+	if gk != gasBlock.Token {
+		t.Fatal("get gas token error")
+	}
+	mh := GenesisMintageHash()
+	if mh != genesisMintageBlock.GetHash() {
+		t.Fatal("get genesis mintage block hash error")
+	}
+	gh := GenesisBlockHash()
+	if gh != genesisBlock.GetHash() {
+		t.Fatal("get genesis block hash error")
+	}
+	gasHash := GasBlockHash()
+	if gasHash != gasBlock.GetHash() {
+		t.Fatal("get gas block hash error")
+	}
+	ab := AllGenesisBlocks()
+	if len(ab) != 4 {
+		t.Fatal("get all block error")
+	}
 }

--- a/config/migration_v5_v6.go
+++ b/config/migration_v5_v6.go
@@ -41,7 +41,6 @@ func (m *MigrationV5ToV6) Migration(data []byte, version int) ([]byte, int, erro
 	cfg6.P2P.BootNodeHttpServer = bootNodeHttpServer
 	cfg6.P2P.BootNodes = bootNodes
 	cfg6.P2P.Discovery.MDNSEnabled = true
-	cfg6.P2P.ListeningIp = "127.0.0.1"
 
 	cfg6.PoV.AlgoName = types.ALGO_SHA256D.String()
 	if cfg6.PoV.ChainParams == nil {

--- a/config/migration_v6_v7.go
+++ b/config/migration_v6_v7.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 QLC Chain Team
+ *
+ * This software is released under the MIT License.
+ * https://opensource.org/licenses/MIT
+ */
+
+package config
+
+import (
+	"encoding/json"
+)
+
+type MigrationV6ToV7 struct {
+	startVersion int
+	endVersion   int
+}
+
+func NewMigrationV6ToV7() *MigrationV6ToV7 {
+	return &MigrationV6ToV7{startVersion: 6, endVersion: 7}
+}
+
+func (m *MigrationV6ToV7) Migration(data []byte, version int) ([]byte, int, error) {
+	var cfg6 ConfigV6
+	err := json.Unmarshal(data, &cfg6)
+	if err != nil {
+		return data, version, err
+	}
+
+	cfg7, err := DefaultConfigV7(cfg6.DataDir)
+	if err != nil {
+		return data, version, err
+	}
+	cfg7.ConfigV6 = cfg6
+	cfg7.Version = configVersion
+	cfg7.P2P.ListeningIp = "127.0.0.1"
+
+	bytes, _ := json.Marshal(cfg7)
+	return bytes, m.endVersion, err
+}
+
+func (m *MigrationV6ToV7) StartVersion() int {
+	return m.startVersion
+}
+
+func (m *MigrationV6ToV7) EndVersion() int {
+	return m.endVersion
+}

--- a/config/migration_v6_v7_test.go
+++ b/config/migration_v6_v7_test.go
@@ -1,0 +1,37 @@
+// +build !testnet
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrationV6ToV7_Migration(t *testing.T) {
+	dir := filepath.Join(QlcTestDataDir(), "config")
+	defer func() { _ = os.RemoveAll(dir) }()
+	cfg6, err := DefaultConfigV6(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := json.Marshal(cfg6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := NewMigrationV6ToV7()
+	migration, i, err := m.Migration(bytes, 6)
+	if err != nil || i != 7 {
+		t.Fatal("migration failed")
+	}
+
+	cfg7 := &Config{}
+	err = json.Unmarshal(migration, cfg7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg7.WhiteList.Enable {
+		t.Fatal("default whitelist is false")
+	}
+}

--- a/config/migration_v6_v7_test.go
+++ b/config/migration_v6_v7_test.go
@@ -34,4 +34,10 @@ func TestMigrationV6ToV7_Migration(t *testing.T) {
 	if cfg7.WhiteList.Enable {
 		t.Fatal("default whitelist is false")
 	}
+	if m.startVersion != 6 {
+		t.Fatal("start version error")
+	}
+	if m.endVersion != 7 {
+		t.Fatal("end version error")
+	}
 }

--- a/config/migration_v6_v7_testnet_test.go
+++ b/config/migration_v6_v7_testnet_test.go
@@ -1,0 +1,37 @@
+// +build testnet
+
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrationV6ToV7_Migration(t *testing.T) {
+	dir := filepath.Join(QlcTestDataDir(), "config")
+	defer func() { _ = os.RemoveAll(dir) }()
+	cfg6, err := DefaultConfigV6(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bytes, err := json.Marshal(cfg6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := NewMigrationV6ToV7()
+	migration, i, err := m.Migration(bytes, 6)
+	if err != nil || i != 7 {
+		t.Fatal("migration failed")
+	}
+
+	cfg7 := &Config{}
+	err = json.Unmarshal(migration, cfg7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg7.WhiteList.Enable {
+		t.Fatal("default whitelist is false")
+	}
+}

--- a/config/migration_v6_v7_testnet_test.go
+++ b/config/migration_v6_v7_testnet_test.go
@@ -34,4 +34,10 @@ func TestMigrationV6ToV7_Migration(t *testing.T) {
 	if cfg7.WhiteList.Enable {
 		t.Fatal("default whitelist is false")
 	}
+	if m.startVersion != 6 {
+		t.Fatal("start version error")
+	}
+	if m.endVersion != 7 {
+		t.Fatal("end version error")
+	}
 }

--- a/ledger/process/ledger_processor.go
+++ b/ledger/process/ledger_processor.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/qlcchain/go-qlc/common"
 	"github.com/qlcchain/go-qlc/common/topic"
 	"github.com/qlcchain/go-qlc/common/types"
@@ -20,7 +22,6 @@ import (
 	"github.com/qlcchain/go-qlc/ledger"
 	"github.com/qlcchain/go-qlc/log"
 	"github.com/qlcchain/go-qlc/vm/vmstore"
-	"go.uber.org/zap"
 )
 
 type LedgerVerifier struct {

--- a/ledger/process/ledger_processor_test.go
+++ b/ledger/process/ledger_processor_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+
 	"github.com/qlcchain/go-qlc/common/storage"
 	"github.com/qlcchain/go-qlc/common/types"
 	"github.com/qlcchain/go-qlc/common/vmcontract/chaincontract"

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -448,18 +448,6 @@ func (node *QlcNode) findPeers() error {
 		return true
 	})
 	for _, p := range peers {
-		if node.cfg.WhiteList.Enable {
-			var in bool
-			for _, v := range node.protector.whiteList {
-				if v == p.ID.Pretty() {
-					in = true
-					break
-				}
-			}
-			if !in {
-				continue
-			}
-		}
 		var pi *types.PeerInfo
 		if v, ok := node.streamManager.onlinePeersInfo.Load(p.ID.Pretty()); ok {
 			pi = v.(*types.PeerInfo)
@@ -487,21 +475,7 @@ func (node *QlcNode) findPeers() error {
 
 func (node *QlcNode) handleStream(s network.Stream) {
 	node.logger.Infof("Got a new stream from %s!", s.Conn().RemotePeer().Pretty())
-	if node.cfg.WhiteList.Enable {
-		var count int
-		for _, v := range node.protector.whiteList {
-			if v == s.Conn().RemotePeer().Pretty() {
-				node.streamManager.Add(s)
-				break
-			}
-			count++
-		}
-		if count == len(node.protector.whiteList)-1 {
-			node.logger.Warnf("refuse connect from %s because it isn't in whitelist", s.Conn().RemotePeer().Pretty())
-		}
-	} else {
-		node.streamManager.Add(s)
-	}
+	node.streamManager.Add(s)
 }
 
 // ID return node ID.

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"reflect"
@@ -132,7 +133,16 @@ func (node *QlcNode) setRepresentativeNode(isRepresentative bool) {
 func (node *QlcNode) updateWhiteList(ip string) {
 	if node.cfg.WhiteList.Enable {
 		if node.protector != nil {
-			node.protector.whiteList = append(node.protector.whiteList, ip)
+			var b bool
+			for _, v := range node.protector.whiteList {
+				if v == ip {
+					b = true
+					break
+				}
+			}
+			if !b {
+				node.protector.whiteList = append(node.protector.whiteList, ip)
+			}
 		}
 	}
 }
@@ -608,6 +618,11 @@ func (node *QlcNode) getBootNode(urls []string) {
 				boot, err := accessHttpServer(v)
 				if err != nil {
 					continue
+				}
+				if node.cfg.WhiteList.Enable {
+					ss := strings.Split(boot, "/")
+					wl := fmt.Sprintf("%s:%s", ss[2], ss[4])
+					node.updateWhiteList(wl)
 				}
 				if len(node.boostrapAddrs) == 0 {
 					node.boostrapAddrs = append(node.boostrapAddrs, boot)

--- a/p2p/node.go
+++ b/p2p/node.go
@@ -130,7 +130,7 @@ func (node *QlcNode) setRepresentativeNode(isRepresentative bool) {
 }
 
 func (node *QlcNode) updateWhiteList(ip string) {
-	if node.cfg.P2P.WhiteListMode {
+	if node.cfg.WhiteList.Enable {
 		if node.protector != nil {
 			node.protector.whiteList = append(node.protector.whiteList, ip)
 		}
@@ -142,7 +142,7 @@ func (node *QlcNode) buildHost() error {
 	go node.getBootNode(node.cfg.P2P.BootNodes)
 	node.logger.Info("Start Qlc Host...")
 	sourceMultiAddr, _ := ma.NewMultiaddr(node.cfg.P2P.Listen)
-	if node.cfg.P2P.WhiteListMode {
+	if node.cfg.WhiteList.Enable {
 		node.host, err = libp2p.New(
 			node.ctx,
 			libp2p.ListenAddrs(sourceMultiAddr),
@@ -448,7 +448,7 @@ func (node *QlcNode) findPeers() error {
 		return true
 	})
 	for _, p := range peers {
-		if node.cfg.P2P.WhiteListMode {
+		if node.cfg.WhiteList.Enable {
 			var in bool
 			for _, v := range node.protector.whiteList {
 				if v == p.ID.Pretty() {
@@ -487,7 +487,7 @@ func (node *QlcNode) findPeers() error {
 
 func (node *QlcNode) handleStream(s network.Stream) {
 	node.logger.Infof("Got a new stream from %s!", s.Conn().RemotePeer().Pretty())
-	if node.cfg.P2P.WhiteListMode {
+	if node.cfg.WhiteList.Enable {
 		var count int
 		for _, v := range node.protector.whiteList {
 			if v == s.Conn().RemotePeer().Pretty() {

--- a/p2p/protector_test.go
+++ b/p2p/protector_test.go
@@ -28,7 +28,7 @@ func TestWhiteListMode(t *testing.T) {
 	cfg.LogLevel = "warn"
 	cfg.P2P.IsBootNode = true
 	cfg.P2P.BootNodes = []string{"127.0.0.1:18001/wlm"}
-	cfg.P2P.WhiteListMode = true
+	cfg.WhiteList.Enable = true
 	http.HandleFunc("/wlm/bootNode", func(w http.ResponseWriter, r *http.Request) {
 		bootNode := cfg.P2P.Listen + "/p2p/" + cfg.P2P.ID.PeerID
 		_, _ = fmt.Fprintf(w, bootNode)

--- a/p2p/protector_test.go
+++ b/p2p/protector_test.go
@@ -29,6 +29,11 @@ func TestWhiteListMode(t *testing.T) {
 	cfg.P2P.IsBootNode = true
 	cfg.P2P.BootNodes = []string{"127.0.0.1:18001/wlm"}
 	cfg.WhiteList.Enable = true
+	w1 := &config.WhiteListInfo{
+		PeerId: "Qmc5VuY4Bys47oyJM1tPoN784ViNDYrh2vEQwGqZBMK5RX",
+		Addr:   "127.0.0.1:18002",
+	}
+	cfg.WhiteList.WhiteListInfos = append(cfg.WhiteList.WhiteListInfos, w1)
 	http.HandleFunc("/wlm/bootNode", func(w http.ResponseWriter, r *http.Request) {
 		bootNode := cfg.P2P.Listen + "/p2p/" + cfg.P2P.ID.PeerID
 		_, _ = fmt.Fprintf(w, bootNode)
@@ -45,23 +50,30 @@ func TestWhiteListMode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	pm := &topic.PermissionEvent{
+		NodeId:  "Qmc5VuY4Bys47oyJM1tPoN784ViNDYrh2vEQwGqZBMK5RX",
+		NodeUrl: "127.0.0.1:18002",
+	}
+	node.msgEvent.Publish(topic.EventPermissionNodeUpdate, pm)
 	node.node.updateWhiteList("127.0.0.1:18002")
 	err = node.Start()
 	if err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println("bootNode id is :", node.Node().ID.Pretty())
 	//node1 config
 	dir1 := filepath.Join(config.QlcTestDataDir(), "whiteListMode", uuid.New().String(), config.QlcConfigFile)
 	cc1 := context.NewChainContext(dir1)
 	cfg1, _ := cc1.Config()
 	cfg1.P2P.Listen = "/ip4/127.0.0.1/tcp/18002"
-	cfg1.P2P.BootNodes = []string{"127.0.0.1:18001/wlm"}
+	cfg1.P2P.BootNodes = []string{"http://127.0.0.1:18001/wlm/bootNode"}
 	cfg1.P2P.Discovery.MDNSEnabled = false
 	cfg1.P2P.Discovery.DiscoveryInterval = 1
 	cfg1.LogLevel = "warn"
+	cfg1.WhiteList.Enable = true
 
 	node.node.boostrapAddrs = append(node.node.boostrapAddrs, cfg1.P2P.Listen+"/p2p/"+cfg1.P2P.ID.PeerID)
+	//start bootNode
+	setPovStatus(cc1, t)
 	//start1 node
 	node1, err := NewQlcService(dir1)
 	if err != nil {

--- a/p2p/qlcService.go
+++ b/p2p/qlcService.go
@@ -141,7 +141,12 @@ func (ns *QlcService) setEvent() error {
 		case *topic.EventP2PSyncStateMsg:
 			ns.msgService.syncService.onConsensusSyncFinished()
 		case *topic.PermissionEvent:
-			ns.node.updateWhiteList(msg.NodeUrl)
+			if len(msg.NodeUrl) != 0 {
+				ns.node.updateWhiteList(msg.NodeUrl)
+			}
+			if len(msg.NodeId) != 0 {
+				ns.node.updateWhiteList(msg.NodeId)
+			}
 		}
 	}), ns.msgEvent)
 

--- a/p2p/qlcService.go
+++ b/p2p/qlcService.go
@@ -43,40 +43,6 @@ func NewQlcService(cfgFile string) (*QlcService, error) {
 	l := ledger.NewLedger(cfgFile)
 	msgService := NewMessageService(ns, l)
 	ns.msgService = msgService
-	if cfg.WhiteList.Enable {
-		ctx := vmstore.NewVMContext(l)
-		pn, err := abi.PermissionGetAllNodes(ctx)
-		if err != nil {
-			return nil, err
-		}
-		for _, v := range pn {
-			if len(v.NodeId) != 0 {
-				node.protector.whiteList = append(node.protector.whiteList, v.NodeId)
-			}
-			node.protector.whiteList = append(node.protector.whiteList, v.NodeUrl)
-		}
-		var wls []string
-		for _, v := range cfg.WhiteList.WhiteListInfos {
-			if len(v.Addr) != 0 {
-				wls = append(wls, v.Addr)
-			}
-			if len(v.PeerId) != 0 {
-				wls = append(wls, v.PeerId)
-			}
-		}
-		for _, v := range wls {
-			var b bool
-			for _, value := range node.protector.whiteList {
-				if value == v {
-					b = true
-					break
-				}
-			}
-			if !b {
-				node.protector.whiteList = append(node.protector.whiteList, v)
-			}
-		}
-	}
 	return ns, nil
 }
 
@@ -98,10 +64,14 @@ func (ns *QlcService) Start() error {
 	ns.dispatcher.Start()
 
 	//set event
-	err := ns.setEvent()
-	if err != nil {
+	if err := ns.setEvent(); err != nil {
 		return err
 	}
+	// set whitelist
+	if err := ns.setWhiteList(); err != nil {
+		return err
+	}
+
 	// start node.
 	if err := ns.node.StartServices(); err != nil {
 		ns.dispatcher.Stop()
@@ -111,6 +81,45 @@ func (ns *QlcService) Start() error {
 	// start msgService
 	ns.msgService.Start()
 	ns.node.logger.Info("Started QlcService.")
+	return nil
+}
+
+func (ns *QlcService) setWhiteList() error {
+	cfg, _ := ns.cc.Config()
+	if cfg.WhiteList.Enable {
+		ctx := vmstore.NewVMContext(ns.msgService.ledger)
+		pn, err := abi.PermissionGetAllNodes(ctx)
+		if err != nil {
+			return err
+		}
+		for _, v := range pn {
+			if len(v.NodeId) != 0 {
+				ns.node.protector.whiteList = append(ns.node.protector.whiteList, v.NodeId)
+			}
+			ns.node.protector.whiteList = append(ns.node.protector.whiteList, v.NodeUrl)
+		}
+		var wls []string
+		for _, v := range cfg.WhiteList.WhiteListInfos {
+			if len(v.Addr) != 0 {
+				wls = append(wls, v.Addr)
+			}
+			if len(v.PeerId) != 0 {
+				wls = append(wls, v.PeerId)
+			}
+		}
+		for _, v := range wls {
+			var b bool
+			for _, value := range ns.node.protector.whiteList {
+				if value == v {
+					b = true
+					break
+				}
+			}
+			if !b {
+				ns.node.protector.whiteList = append(ns.node.protector.whiteList, v)
+			}
+		}
+	}
 	return nil
 }
 

--- a/rpc/api/ledger.go
+++ b/rpc/api/ledger.go
@@ -10,6 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	rpc "github.com/qlcchain/jsonrpc2"
+	"go.uber.org/zap"
+
 	chainctx "github.com/qlcchain/go-qlc/chain/context"
 	"github.com/qlcchain/go-qlc/common/event"
 	"github.com/qlcchain/go-qlc/common/types"
@@ -20,8 +23,6 @@ import (
 	"github.com/qlcchain/go-qlc/log"
 	"github.com/qlcchain/go-qlc/vm/contract/abi"
 	"github.com/qlcchain/go-qlc/vm/vmstore"
-	rpc "github.com/qlcchain/jsonrpc2"
-	"go.uber.org/zap"
 )
 
 var (


### PR DESCRIPTION
### Proposed changes in this pull request

- add permission service to add preconfigured nodes automatically
- add preconfigured nodes in config file

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
