### PR TITLE
hotfix: delete the cache block instantly can cause high disk usage

### DIFF
--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -202,7 +202,7 @@ func (l *Ledger) removeBlockConfirmed() error {
 				if len(l.blockConfirmed) > 0 {
 					for b := range l.blockConfirmed {
 						blocks = append(blocks, b)
-						if len(blocks) >= 1000 {
+						if len(blocks) >= 10000 {
 							break
 						}
 						if len(l.blockConfirmed) == 0 {

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -114,7 +114,7 @@ func NewLedger(cfgFile string) *Ledger {
 			EB:             cc.EventBus(),
 			ctx:            ctx,
 			cancel:         cancel,
-			blockConfirmed: make(chan *types.StateBlock, 1024),
+			blockConfirmed: make(chan *types.StateBlock, 10240),
 			deletedSchema:  make([]types.Schema, 0),
 			logger:         log.NewLogger("ledger"),
 			tokenCache:     sync.Map{},
@@ -200,6 +200,9 @@ func (l *Ledger) removeBlockConfirmed() error {
 				if len(l.blockConfirmed) > 0 {
 					for b := range l.blockConfirmed {
 						blocks = append(blocks, b)
+						if len(blocks) >= 1000 {
+							break
+						}
 						if len(l.blockConfirmed) == 0 {
 							break
 						}

--- a/ledger/process/ledger_processor.go
+++ b/ledger/process/ledger_processor.go
@@ -271,7 +271,7 @@ func (lv *LedgerVerifier) BlockProcess(block *types.StateBlock) error {
 	}
 	lv.logger.Debug("publish addRelation,", block.GetHash())
 	lv.l.EventBus().Publish(topic.EventAddRelation, block)
-	lv.l.BlockConfirmed(block)
+	//lv.l.BlockConfirmed(block)
 	return nil
 }
 

--- a/ledger/process/ledger_processor.go
+++ b/ledger/process/ledger_processor.go
@@ -271,7 +271,7 @@ func (lv *LedgerVerifier) BlockProcess(block *types.StateBlock) error {
 	}
 	lv.logger.Debug("publish addRelation,", block.GetHash())
 	lv.l.EventBus().Publish(topic.EventAddRelation, block)
-	//lv.l.BlockConfirmed(block)
+	lv.l.BlockConfirmed(block)
 	return nil
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request

- delete the cache block instantly can cause high disk usage

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [ ] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [ ] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
