### PR TITLE
fix: upgrade ledger to reset pending infos

### DIFF
--- a/common/storage/storage.go
+++ b/common/storage/storage.go
@@ -93,6 +93,7 @@ const (
 	KeyPrefixContractValue = 103 // idPrefixContractValue ledger.go
 	KeyPrefixVmLogs        = 104 // vm_store.go
 	KeyPrefixVMStorage     = 105 // vm_store.go
+	KeyPrefixPendingBackup = 253
 	KeyPrefixGenericType   = 254
 	KeyPrefixGenericTypeC  = 255
 )

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -99,7 +99,7 @@ var (
 	lock   = sync.RWMutex{}
 )
 
-const version = 15
+const version = 16
 
 func NewLedger(cfgFile string) *Ledger {
 	lock.Lock()
@@ -265,6 +265,7 @@ func (l *Ledger) upgrade() error {
 			new(migration.MigrationV12ToV13),
 			new(migration.MigrationV13ToV14),
 			new(migration.MigrationV14ToV15),
+			new(migration.MigrationV15ToV16),
 		}
 
 		err = migration.Upgrade(ms, l.store)

--- a/ledger/ledger_pending.go
+++ b/ledger/ledger_pending.go
@@ -81,10 +81,10 @@ func (l *Ledger) GetPendings(fn func(pendingKey *types.PendingKey, pendingInfo *
 		}
 		pendingInfo := new(types.PendingInfo)
 		if err := pendingInfo.Deserialize(val); err != nil {
-			return fmt.Errorf("pendingKey deserialize: %s", err)
+			return fmt.Errorf("pendingInfo deserialize: %s", err)
 		}
 		if err := fn(pendingKey, pendingInfo); err != nil {
-			return fmt.Errorf("pendingKey deserialize: %s", err)
+			return fmt.Errorf("pending func: %s", err)
 		}
 		return nil
 	})

--- a/ledger/migration/migration.go
+++ b/ledger/migration/migration.go
@@ -348,6 +348,10 @@ func (m MigrationV15ToV16) Migrate(store storage.Store) error {
 				}
 				return updateVersion(m, batch)
 			})
+		} else {
+			return store.BatchWrite(false, func(batch storage.Batch) error {
+				return updateVersion(m, batch)
+			})
 		}
 	}
 	return nil

--- a/ledger/migration/migration_test.go
+++ b/ledger/migration/migration_test.go
@@ -72,7 +72,7 @@ func TestMigration_Migrate(t *testing.T) {
 	if err := store.Put(frontierK, frontierV); err != nil {
 		t.Fatal(err)
 	}
-	migrations := []Migration{MigrationV11ToV12{}, MigrationV12ToV13{}, MigrationV13ToV14{}, MigrationV14ToV15{}}
+	migrations := []Migration{MigrationV11ToV12{}, MigrationV12ToV13{}, MigrationV13ToV14{}, MigrationV14ToV15{}, MigrationV15ToV16{}}
 	if err := Upgrade(migrations, store); err != nil {
 		t.Fatal(err)
 	}

--- a/ledger/migration/migration_test.go
+++ b/ledger/migration/migration_test.go
@@ -2,6 +2,7 @@ package migration
 
 import (
 	"encoding/binary"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -118,4 +119,52 @@ func TestMigration_MigrateV14ToV15(t *testing.T) {
 		t.Fatal(err)
 	}
 
+}
+
+func TestMigration_MigrateV15ToV16(t *testing.T) {
+	dir := filepath.Join(config.QlcTestDataDir(), "store", uuid.New().String())
+	store, err := db.NewBadgerStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		os.Remove(dir)
+	}()
+
+	key := []byte{byte(storage.KeyPrefixVersion)}
+	buf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutVarint(buf, 15)
+	if err := store.Put(key, buf[:n]); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 10; i++ {
+		pendingKey := &types.PendingKey{
+			Address: mock.Address(),
+			Hash:    mock.Hash(),
+		}
+		pendingInfo := &types.PendingInfo{
+			Source: mock.Address(),
+			Type:   mock.Hash(),
+			Amount: types.Balance{Int: big.NewInt(100)},
+		}
+		kBytes, err := pendingKey.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pk := make([]byte, 0)
+		pk = append(pk, byte(storage.KeyPrefixPending))
+		pk = append(pk, kBytes...)
+		iBytes, err := pendingInfo.MarshalMsg(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Put(pk, iBytes); err != nil {
+			t.Fatal(err)
+		}
+	}
+	migrations := []Migration{MigrationV15ToV16{}}
+	if err := Upgrade(migrations, store); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/rpc/api/ledger_test.go
+++ b/rpc/api/ledger_test.go
@@ -261,8 +261,11 @@ func TestLedgerAPI_AccountBlocksCount(t *testing.T) {
 }
 
 func TestLedgerAPI_AccountHistoryTopn(t *testing.T) {
-	teardownTestCase, _, ledgerApi := setupDefaultLedgerAPI(t)
+	teardownTestCase, l, ledgerApi := setupDefaultLedgerAPI(t)
 	defer teardownTestCase(t)
+	if err := l.Flush(); err != nil {
+		t.Fatal(err)
+	}
 	r, err := ledgerApi.AccountHistoryTopn(account1.Address(), 100, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/rpc/grpc/apis/ledger_test.go
+++ b/rpc/grpc/apis/ledger_test.go
@@ -140,8 +140,11 @@ func TestLedgerAPI_AccountBlocksCount(t *testing.T) {
 }
 
 func TestLedgerAPI_AccountHistoryTopn(t *testing.T) {
-	teardownTestCase, _, ledgerApi := setupDefaultLedgerAPI(t)
+	teardownTestCase, l, ledgerApi := setupDefaultLedgerAPI(t)
 	defer teardownTestCase(t)
+	if err := l.Flush(); err != nil {
+		t.Fatal(err)
+	}
 	r, err := ledgerApi.AccountHistoryTopn(context.Background(), &pb.AccountHistoryTopnReq{
 		Address: account1.Address().String(),
 		Count:   100,


### PR DESCRIPTION
### Proposed changes in this pull request

migration ledger to reset pendings, fix bug:
```
 "pendingKey deserialize: invalid Hash size"
```

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
