### PR TITLE
fix: wrong block into ledger cache && `DoDSettlement_GetPendingResourceCheck` return incorrect order infos

### DIFF
--- a/cmd/server/commands/root.go
+++ b/cmd/server/commands/root.go
@@ -23,6 +23,8 @@ import (
 	"github.com/abiosoft/readline"
 	"github.com/spf13/cobra"
 
+	"github.com/qlcchain/go-qlc/common/util"
+
 	"github.com/qlcchain/go-qlc/chain"
 	"github.com/qlcchain/go-qlc/chain/context"
 	cmdutil "github.com/qlcchain/go-qlc/cmd/util"
@@ -252,6 +254,10 @@ func start() error {
 		chainContext.EventBus().Publish(topic.EventPovSyncState, topic.SyncDone)
 		chainContext.EventBus().Publish(topic.EventAddP2PStream, &topic.EventAddP2PStreamMsg{PeerID: cfg.P2P.ID.PeerID})
 	}
+
+	c, _ := cm.Config()
+	log.Root.Info(util.ToIndentString(c))
+
 	err = chainContext.Start()
 
 	if err != nil {

--- a/ledger/process/ledger_check.go
+++ b/ledger/process/ledger_check.go
@@ -52,9 +52,9 @@ func (blockBaseInfoCheck) baseInfo(lv *LedgerVerifier, block *types.StateBlock) 
 
 	if block.GetType() == types.ContractReward {
 		// check private tx
-		if block.IsPrivate() && !block.IsRecipient() {
-			return Progress, nil
-		}
+		//if block.IsPrivate() && !block.IsRecipient() {
+		//	return Progress, nil
+		//}
 
 		linkBlk, err := lv.l.GetStateBlockConfirmed(block.GetLink())
 		if err != nil {
@@ -117,9 +117,9 @@ func (cacheBlockBaseInfoCheck) baseInfo(lv *LedgerVerifier, block *types.StateBl
 
 	if block.GetType() == types.ContractReward {
 		// check private tx
-		if block.IsPrivate() && !block.IsRecipient() {
-			return Progress, nil
-		}
+		//if block.IsPrivate() && !block.IsRecipient() {
+		//	return Progress, nil
+		//}
 
 		linkBlk, err := lv.l.GetStateBlock(block.GetLink())
 		if err != nil {

--- a/privacy/privacy.go
+++ b/privacy/privacy.go
@@ -124,7 +124,7 @@ func (c *Controller) onEventPrivacySendReqMsg(msg *topic.EventPrivacySendReqMsg)
 	rspMsg.EnclaveKey, rspMsg.Err = c.ptm.Send(msg.RawPayload, msg.PrivateFrom, msg.PrivateFor)
 
 	if rspMsg.Err != nil {
-		c.logger.Debugf("PrivacySendReq Event, PrivateFrom:%s, return Err:%s", msg.PrivateFrom, rspMsg.Err)
+		c.logger.Errorf("PrivacySendReq Event, PrivateFrom:%s, return Err:%s", msg.PrivateFrom, rspMsg.Err)
 	} else {
 		c.logger.Debugf("PrivacySendReq Event, PrivateFrom:%s, return EnclaveKey:%s", msg.PrivateFrom, formatBytesPrefix(rspMsg.EnclaveKey))
 	}
@@ -137,7 +137,7 @@ func (c *Controller) onEventPrivacyRecvReqMsg(msg *topic.EventPrivacyRecvReqMsg)
 	rspMsg.RawPayload, rspMsg.Err = c.ptm.Receive(msg.EnclaveKey)
 
 	if rspMsg.Err != nil {
-		c.logger.Debugf("PrivacyRecvReq Event, EnclaveKey:%s, return Err:%s", formatBytesPrefix(msg.EnclaveKey), rspMsg.Err)
+		c.logger.Errorf("PrivacyRecvReq Event, EnclaveKey:%s, return Err:%s", formatBytesPrefix(msg.EnclaveKey), rspMsg.Err)
 	} else {
 		c.logger.Debugf("PrivacyRecvReq Event, EnclaveKey:%s, return RawPayload:%s", formatBytesPrefix(msg.EnclaveKey), formatBytesPrefix(rspMsg.RawPayload))
 	}

--- a/rpc/api/dod_settlement.go
+++ b/rpc/api/dod_settlement.go
@@ -386,7 +386,7 @@ func (d *DoDSettlementAPI) GetPendingRequest(address types.Address) ([]*DoDPendi
 		}
 
 		if sendBlock.Type == types.ContractSend && sendBlock.Link == contractaddress.DoDSettlementAddress.ToHash() {
-			method, err := abi.DoDSettlementABI.MethodById(sendBlock.Data)
+			method, err := abi.DoDSettlementABI.MethodById(sendBlock.GetPayload())
 			if err != nil {
 				return err
 			}

--- a/rpc/api/dod_settlement.go
+++ b/rpc/api/dod_settlement.go
@@ -434,14 +434,15 @@ func (d *DoDSettlementAPI) GetPendingResourceCheck(address types.Address) ([]*Do
 		}
 
 		if sendBlock.Type == types.ContractSend && sendBlock.Link == contractaddress.DoDSettlementAddress.ToHash() {
-			method, err := abi.DoDSettlementABI.MethodById(sendBlock.Data)
+			payload := sendBlock.GetPayload()
+			method, err := abi.DoDSettlementABI.MethodById(payload)
 			if err != nil {
 				return err
 			}
 
 			if method.Name == abi.MethodNameDoDSettleUpdateOrderInfo {
 				param := new(abi.DoDSettleUpdateOrderInfoParam)
-				err = param.FromABI(sendBlock.Data)
+				err = param.FromABI(payload)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
### Proposed changes in this pull request

- fix #1328
- fix #1329

### Type
- [ ] Bug fix: (Link to the issue #{issue No.})
- [x] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
