### PR TITLE
fix: node without ptm can not synchronize privacy block

### DIFF
--- a/consensus/dpos/dpos_impl_testnet.go
+++ b/consensus/dpos/dpos_impl_testnet.go
@@ -504,8 +504,13 @@ func (dps *DPoS) processPrivateBlocks() {
 
 		case bs := <-dps.privateRecvBlocks:
 			if bs.Block.IsPrivate() {
-				recvReq := &topic.EventPrivacyRecvReqMsg{EnclaveKey: bs.Block.GetData(), ReqData: bs, RspChan: dps.privateRecvRspCh}
-				dps.eb.Publish(topic.EventPrivacySendReq, recvReq)
+				if dps.cfg.Privacy.Enable {
+					recvReq := &topic.EventPrivacyRecvReqMsg{EnclaveKey: bs.Block.GetData(), ReqData: bs, RspChan: dps.privateRecvRspCh}
+					dps.eb.Publish(topic.EventPrivacySendReq, recvReq)
+				} else {
+					rspMsg := &topic.EventPrivacyRecvRspMsg{ReqData: bs}
+					dps.privateRecvRspCh <- rspMsg
+				}
 			}
 
 		case recvRsp := <-dps.privateRecvRspCh:

--- a/vm/contract/dod_settlement.go
+++ b/vm/contract/dod_settlement.go
@@ -585,7 +585,6 @@ func (uo *DoDSettleUpdateOrderInfo) DoReceive(ctx *vmstore.VMContext, block *typ
 	}
 
 	if block.Address.IsZero() {
-
 		// generate contract reward block
 		block.Type = types.ContractReward
 		block.Address = order.Seller.Address

--- a/vm/contract/dod_settlement.go
+++ b/vm/contract/dod_settlement.go
@@ -585,6 +585,7 @@ func (uo *DoDSettleUpdateOrderInfo) DoReceive(ctx *vmstore.VMContext, block *typ
 	}
 
 	if block.Address.IsZero() {
+
 		// generate contract reward block
 		block.Type = types.ContractReward
 		block.Address = order.Seller.Address


### PR DESCRIPTION
### Proposed changes in this pull request

- fix: #1336

### Type
- [x] Bug fix: (Link to the issue #{issue No.})
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md).
- [ ] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable.
- [x] Code has been written according to [Golang-Style-Guide](https://github.com/qlcchain/go-qlc/blob/master/CONTRIBUTING.md#code-standard)

### Extra information
Any extra information related to this pull request.
